### PR TITLE
Re-enable TPC-H on Ursa i9

### DIFF
--- a/config.py
+++ b/config.py
@@ -70,6 +70,7 @@ class Config:
                                 "file-write",
                                 "partitioned-dataset-filter",
                                 "wide-dataframe",
+                                "tpch"
                             ]
                         },
                         "JavaScript": {"names": ["js-micro"]},


### PR DESCRIPTION
This might be temporary until we can lower the memory hungriness (folks are looking at that no the query engine team now). But for now, lets run them on both machines so we have a reliable way to test the PRs that have that optimization.