### PR TITLE
Only build duckdb if we need to

### DIFF
--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -74,18 +74,23 @@ install_arrowbench() {
 }
 
 install_duckdb_r_with_tpch() {
-  git clone https://github.com/duckdb/duckdb.git
-  
-  # now fetch the latest tag to install
-  cd duckdb
-  git fetch --tags
-  latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
-  git checkout $latestTag
-  
-  # and then do the install
-  cd tools/rpkg
-  R -e "remotes::install_deps()"
-  DUCKDB_R_EXTENSIONS=tpch R CMD INSTALL .
+  # Check if duckdb is already installed
+  R -e "stopifnot(require('duckdb'))"
+  if test $? -ne 0; then
+    # If it is not already installed, then we should isntall it.
+    git clone https://github.com/duckdb/duckdb.git
+
+    # now fetch the latest tag to install
+    cd duckdb
+    git fetch --tags
+    latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
+    git checkout $latestTag
+
+    # and then do the install
+    cd tools/rpkg
+    R -e "remotes::install_deps()"
+    DUCKDB_R_EXTENSIONS=tpch R CMD INSTALL .
+  fi
 }
 
 install_java_script_project_dependencies() {


### PR DESCRIPTION
We will want to install duckdb manually (using the code that this does) in `/var/lib/buildkite-agent/miniconda3/envs/arrow-commit/lib/R/library` (which I got from the buildkite log).

We might also need edit https://github.com/apache/arrow/blob/master/dev/conbench_envs/hooks.sh#L65-L67 to prevent it from trying to install duckdb _over_ what we have installed.