### PR TITLE
Added benchmark machine test-mac-arm, a Mac mini M1

### DIFF
--- a/config.py
+++ b/config.py
@@ -123,6 +123,21 @@ class Config:
             "offline_warning_enabled": False,
             "publish_benchmark_results": True,
         },
+        "test-mac-arm": {
+            "info": "Supported benchmark langs: C++, Python, R",
+            "default_filters": {
+                "arrow-commit": {
+                    "langs": {
+                        "Python": {"names": ["dataset-read", "dataset-select"]},
+                        "C++": {"names": ["cpp-micro"]},
+                        "R": {"names": ["tpch"]}
+                    }
+                },
+            },
+            "supported_filters": ["lang", "name"],
+            "offline_warning_enabled": False,
+            "publish_benchmark_results": False,
+        },
         "voltron-pavilion": {
             "info": "Supported benchmark langs: Python, R, JavaScript, C++, Java",
             "default_filters": {"arrow-commit": {"langs": {"R": {"names": ["tpch"]}}}},


### PR DESCRIPTION
It would be nice to add benchmarks on ARM, and we have a dedicated machine for this available. It already has a buildkite queue with the same name (test-mac-arm).
I just added a selection of benchmarks, please let me know if these are appropriate.