### PR TITLE
Add arrow-rs & arrow-datafusion benchmarks

### DIFF
--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -62,6 +62,28 @@ repos_with_benchmark_groups = [
         "setup_commands_for_lang_benchmarks": {},
         "env_vars": {},
     },
+    {
+        "benchmarkable_type": "arrow-rs-commit",
+        "repo": "https://github.com/apache/arrow-rs.git",
+        "root": "arrow-rs/conbench",
+        "branch": "master",
+        "setup_commands": ["pip install -r requirements.txt"],
+        "path_to_benchmark_groups_list_json": "arrow-rs/conbench/benchmarks.json",
+        "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/apache/arrow-rs/master/conbench/benchmarks.json",
+        "setup_commands_for_lang_benchmarks": {},
+        "env_vars": {},
+    },
+    {
+        "benchmarkable_type": "arrow-datafusion-commit",
+        "repo": "https://github.com/apache/arrow-datafusion.git",
+        "root": "arrow-datafusion/conbench",
+        "branch": "master",
+        "setup_commands": ["pip install -r requirements.txt"],
+        "path_to_benchmark_groups_list_json": "arrow-datafusion/conbench/benchmarks.json",
+        "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/apache/arrow-datafusion/master/conbench/benchmarks.json",
+        "setup_commands_for_lang_benchmarks": {},
+        "env_vars": {},
+    },
 ]
 
 retryable_benchmark_groups = [

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -12,7 +12,7 @@ from utils import generate_uuid
 
 from .run_utils import post_logs_to_arrow_bci, run_context
 
-benchmark_langs = ["C++", "Java", "Python", "R", "JavaScript"]
+benchmark_langs = ["C++", "Java", "Python", "R", "JavaScript", "Rust"]
 benchmarkable_id = os.getenv("BENCHMARKABLE")
 run_id = os.getenv("RUN_ID")
 run_name = os.getenv("RUN_NAME")

--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -55,6 +55,20 @@ create_conda_env_for_benchmarkable_repo_commit() {
   conda activate "${BENCHMARKABLE_TYPE}"
 }
 
+create_conda_env_for_arrow_rs_commit() {
+  conda create -y -n "${BENCHMARKABLE_TYPE}" -c conda-forge \
+    python="3.9" \
+    rust
+  conda activate "${BENCHMARKABLE_TYPE}"
+}
+
+create_conda_env_for_arrow_datafusion_commit() {
+  conda create -y -n "${BENCHMARKABLE_TYPE}" -c conda-forge \
+    python="3.9" \
+    rust
+  conda activate "${BENCHMARKABLE_TYPE}"
+}
+
 clone_repo() {
   rm -rf arrow
   git clone "${REPO}"
@@ -148,6 +162,18 @@ create_conda_env_and_run_benchmarks() {
       export REPO_DIR=benchmarkable-repo
       clone_repo
       create_conda_env_for_benchmarkable_repo_commit
+      ;;
+    "arrow-rs-commit")
+      export REPO=https://github.com/apache/arrow-rs.git
+      export REPO_DIR=arrow-rs
+      clone_repo
+      create_conda_env_for_arrow_rs_commit
+      ;;
+    "arrow-datafusion-commit")
+      export REPO=https://github.com/apache/arrow-datafusion.git
+      export REPO_DIR=arrow-datafusion
+      clone_repo
+      create_conda_env_for_arrow_datafusion_commit
       ;;
   esac
 

--- a/config.py
+++ b/config.py
@@ -30,6 +30,16 @@ class Config:
             "enable_benchmarking_for_pull_requests": False,
             "github_secret": None,
         },
+        "apache/arrow-rs": {
+            "benchmarkable_type": "arrow-rs-commit",
+            "enable_benchmarking_for_pull_requests": False,
+            "github_secret": None,
+        },        
+        "apache/arrow-datafusion": {
+            "benchmarkable_type": "arrow-datafusion-commit",
+            "enable_benchmarking_for_pull_requests": False,
+            "github_secret": None,
+        },        
     }
     GITHUB_REPO = os.getenv("GITHUB_REPO")
     MAX_COMMITS_TO_FETCH = os.getenv("MAX_COMMITS_TO_FETCH", 20)


### PR DESCRIPTION
@andygrove Here's a pull request for the next steps outlined in this doc.

https://github.com/ursacomputing/arrow-benchmarks-ci/blob/main/docs/how-to-add-new-benchmarkable-repo.md

1. Integrate benchmarks in benchmarkable repo with Conbench
a. <b>Already done in the arrow-rs & arrow-datafusion repos</b>
1. Add benchmarks.json to benchmarkable repo
a. <b>Already done in the arrow-rs & arrow-datafusion repos</b>
1. Create Pull Request to add new benchmarkable repo to Arrow Benchmarks CI
a. <b>That is this pull request</b>
4. Add machine to run benchmarks for benchmarkable repo
a. <b>Andy: you'll need to do this (see these docs: https://github.com/ursacomputing/arrow-benchmarks-ci/blob/main/docs/how-to-add-new-benchmark-machine.md)</b>

PS. All this code is actually from @ElenaHenderson – you're the best, miss you!