### PR TITLE
Post Buildkite build urls into pull request comments

### DIFF
--- a/models/notification.py
+++ b/models/notification.py
@@ -98,7 +98,12 @@ class Notification(Base, BaseMixin):
         text += self.generate_comment_with_compare_runs_links()
 
         # Add links to buildkite builds
-        text += f"Buildkite builds:\n"
+        text += self.generate_comment_with_compare_runs_links()
+
+        return text
+
+    def generate_text_with_buildkite_build_urls(self):
+        text = f"Buildkite builds:\n"
         for run in (
             self.benchmarkable.runs_with_buildkite_builds_and_publishable_benchmark_results
             + self.benchmarkable.baseline.runs_with_buildkite_builds_and_publishable_benchmark_results

--- a/models/notification.py
+++ b/models/notification.py
@@ -98,7 +98,7 @@ class Notification(Base, BaseMixin):
         text += self.generate_comment_with_compare_runs_links()
 
         # Add links to buildkite builds
-        text += self.generate_comment_with_compare_runs_links()
+        text += self.generate_text_with_buildkite_build_urls()
 
         return text
 

--- a/models/notification.py
+++ b/models/notification.py
@@ -84,6 +84,7 @@ class Notification(Base, BaseMixin):
         return (
             comment
             + self.generate_comment_with_compare_runs_links()
+            + self.generate_text_with_buildkite_build_urls()
             + supported_benchmarks_info()
         )
 

--- a/models/notification.py
+++ b/models/notification.py
@@ -94,13 +94,11 @@ class Notification(Base, BaseMixin):
             f"contender {self.benchmarkable.slack_text}\n"
             f"baseline {self.benchmarkable.baseline.slack_text}:\n"
         )
-        # Add conbench compare/runs links with status
-        text += self.generate_comment_with_compare_runs_links()
-
-        # Add links to buildkite builds
-        text += self.generate_text_with_buildkite_build_urls()
-
-        return text
+        return (
+            text
+            + self.generate_comment_with_compare_runs_links()
+            + self.generate_text_with_buildkite_build_urls()
+        )
 
     def generate_text_with_buildkite_build_urls(self):
         text = f"Buildkite builds:\n"

--- a/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
+++ b/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
@@ -72,12 +72,12 @@ def test_generate_pull_comment_body(client):
         (
             [(benchmarkable.baseline_machine_run(machine1), "finished")],
             [scheduled_status_with_warning, skipped_status],
-            ["Finished", "Scheduled", "Scheduled"],
+            ["Scheduled", "Finished", "Scheduled"],
         ),
         (
             [(benchmarkable.machine_run(machine1), "failed")],
             [failed_status, skipped_status],
-            ["Finished", "Failed", "Scheduled"],
+            ["Failed", "Finished", "Scheduled"],
         ),
         (
             [(benchmarkable.machine_run(machine1), "finished")],

--- a/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
+++ b/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
@@ -72,27 +72,27 @@ def test_generate_pull_comment_body(client):
         (
             [(benchmarkable.baseline_machine_run(machine1), "finished")],
             [scheduled_status_with_warning, skipped_status],
-            ["Scheduled", "Scheduled", "Scheduled"],
+            ["Finished", "Scheduled", "Scheduled"],
         ),
         (
             [(benchmarkable.machine_run(machine1), "failed")],
             [failed_status, skipped_status],
-            ["Scheduled", "Scheduled", "Scheduled"],
+            ["Finished", "Scheduled", "Scheduled"],
         ),
         (
             [(benchmarkable.machine_run(machine1), "finished")],
             [finished_status, skipped_status],
-            ["Scheduled", "Scheduled", "Scheduled"],
+            ["Finished", "Scheduled", "Scheduled"],
         ),
         (
             [(benchmarkable.baseline_machine_run(machine2), "finished")],
             [finished_status, skipped_status],
-            ["Scheduled", "Scheduled", "Scheduled"],
+            ["Finished", "Scheduled", "Scheduled"],
         ),
         (
             [(benchmarkable.machine_run(machine2), "finished")],
             [finished_status, finished_status],
-            ["Scheduled", "Scheduled", "Scheduled"],
+            ["Finished", "Scheduled", "Scheduled"],
         ),
     ]
     for input_run_statuses, expected_statuses in test_cases:

--- a/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
+++ b/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
@@ -42,9 +42,9 @@ def verify_pull_comment(input_run_statuses, expected_statuses, expected_build_st
         f"[{expected_statuses[0]}] [{machine1.name}]({benchmarkable.conbench_compare_runs_web_url(machine1)})\n"
         f"[{expected_statuses[1]}] [{machine2.name}]({benchmarkable.conbench_compare_runs_web_url(machine2)})\n"
         "Buildkite builds:\n"
-        f"[{expected_build_statuses[0]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine1.name} / builds / 1 | `{test_benchmarkable_id}` {machine1.name} >"
-        f"[{expected_build_statuses[1]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine1.name} / builds / 1 | `{test_baseline_benchmarkable_id}` {machine1.name} >"
-        f"[{expected_build_statuses[2]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine2.name} / builds / 1 | `{test_baseline_benchmarkable_id}` {machine2.name} >"
+        f"[{expected_build_statuses[0]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine1.name} / builds / 1 | `{test_benchmarkable_id}` {machine1.name} >\n"
+        f"[{expected_build_statuses[1]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine1.name} / builds / 1 | `{test_baseline_benchmarkable_id}` {machine1.name} >\n"
+        f"[{expected_build_statuses[2]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine2.name} / builds / 1 | `{test_baseline_benchmarkable_id}` {machine2.name} >\n"
         f"{support_benchmarks_info}\n"
     )
 

--- a/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
+++ b/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
@@ -77,22 +77,22 @@ def test_generate_pull_comment_body(client):
         (
             [(benchmarkable.machine_run(machine1), "failed")],
             [failed_status, skipped_status],
-            ["Finished", "Scheduled", "Scheduled"],
+            ["Finished", "Failed", "Scheduled"],
         ),
         (
             [(benchmarkable.machine_run(machine1), "finished")],
             [finished_status, skipped_status],
-            ["Finished", "Scheduled", "Scheduled"],
+            ["Finished", "Finished", "Scheduled"],
         ),
         (
             [(benchmarkable.baseline_machine_run(machine2), "finished")],
             [finished_status, skipped_status],
-            ["Finished", "Scheduled", "Scheduled"],
+            ["Finished", "Finished", "Finished"],
         ),
         (
             [(benchmarkable.machine_run(machine2), "finished")],
             [finished_status, finished_status],
-            ["Finished", "Scheduled", "Scheduled"],
+            ["Finished", "Finished", "Finished"],
         ),
     ]
     for input_run_statuses, expected_statuses in test_cases:

--- a/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
+++ b/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
@@ -42,9 +42,9 @@ def verify_pull_comment(input_run_statuses, expected_statuses, expected_build_st
         f"[{expected_statuses[0]}] [{machine1.name}]({benchmarkable.conbench_compare_runs_web_url(machine1)})\n"
         f"[{expected_statuses[1]}] [{machine2.name}]({benchmarkable.conbench_compare_runs_web_url(machine2)})\n"
         "Buildkite builds:\n"
-        f"[{expected_build_statuses[0]}] <https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-{machine1.name}/builds/1| `{test_benchmarkable_id}` {machine1.name} >\n"
-        f"[{expected_build_statuses[1]}] <https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-{machine1.name}/builds/1| `{test_baseline_benchmarkable_id}` {machine1.name} >\n"
-        f"[{expected_build_statuses[2]}] <https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-{machine2.name}/builds/1| `{test_baseline_benchmarkable_id}` {machine2.name} >\n"
+        f"[{expected_build_statuses[0]}] <https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-{machine1.name}/builds/1| `{test_benchmarkable_id}` {machine1.name}>\n"
+        f"[{expected_build_statuses[1]}] <https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-{machine1.name}/builds/1| `{test_baseline_benchmarkable_id}` {machine1.name}>\n"
+        f"[{expected_build_statuses[2]}] <https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-{machine2.name}/builds/1| `{test_baseline_benchmarkable_id}` {machine2.name}>\n"
         f"{support_benchmarks_info}\n"
     )
 

--- a/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
+++ b/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
@@ -67,6 +67,7 @@ def test_generate_pull_comment_body(client):
         (
             [],
             [scheduled_status_with_warning, skipped_status],
+            ["Scheduled", "Scheduled", "Scheduled"],
         ),
         (
             [(benchmarkable.baseline_machine_run(machine1), "finished")],

--- a/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
+++ b/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
@@ -42,9 +42,9 @@ def verify_pull_comment(input_run_statuses, expected_statuses, expected_build_st
         f"[{expected_statuses[0]}] [{machine1.name}]({benchmarkable.conbench_compare_runs_web_url(machine1)})\n"
         f"[{expected_statuses[1]}] [{machine2.name}]({benchmarkable.conbench_compare_runs_web_url(machine2)})\n"
         "Buildkite builds:\n"
-        f"[{expected_build_statuses[0]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine1.name} / builds / 1 | `{test_benchmarkable_id}` {machine1.name} >\n"
-        f"[{expected_build_statuses[1]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine1.name} / builds / 1 | `{test_baseline_benchmarkable_id}` {machine1.name} >\n"
-        f"[{expected_build_statuses[2]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine2.name} / builds / 1 | `{test_baseline_benchmarkable_id}` {machine2.name} >\n"
+        f"[{expected_build_statuses[0]}] <https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-{machine1.name}/builds/1| `{test_benchmarkable_id}` {machine1.name} >\n"
+        f"[{expected_build_statuses[1]}] <https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-{machine1.name}/builds/1| `{test_baseline_benchmarkable_id}` {machine1.name} >\n"
+        f"[{expected_build_statuses[2]}] <https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-{machine2.name}/builds/1| `{test_baseline_benchmarkable_id}` {machine2.name} >\n"
         f"{support_benchmarks_info}\n"
     )
 

--- a/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
+++ b/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
@@ -95,8 +95,8 @@ def test_generate_pull_comment_body(client):
             ["Finished", "Finished", "Finished"],
         ),
     ]
-    for input_run_statuses, expected_statuses in test_cases:
-        verify_pull_comment(input_run_statuses, expected_statuses)
+    for input_run_statuses, expected_statuses, expected_build_statuses in test_cases:
+        verify_pull_comment(input_run_statuses, expected_statuses, expected_build_statuses)
 
 
 def test_publish_benchmark_results_on_pull_requests(client):

--- a/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
+++ b/tests/buildkite/schedule_and_publish/test_publish_benchmark_results_on_pull_requests.py
@@ -25,7 +25,7 @@ ursa-i9-9960x: Supported benchmark langs: Python, R, JavaScript
 ursa-thinkcentre-m75q: Supported benchmark langs: C++, Java"""
 
 
-def verify_pull_comment(input_run_statuses, expected_statuses):
+def verify_pull_comment(input_run_statuses, expected_statuses, expected_build_statuses):
     for (run, status) in input_run_statuses:
         run.finished_at = s.sql.func.now()
         run.status = status
@@ -41,6 +41,10 @@ def verify_pull_comment(input_run_statuses, expected_statuses):
         f"Conbench compare runs links:\n"
         f"[{expected_statuses[0]}] [{machine1.name}]({benchmarkable.conbench_compare_runs_web_url(machine1)})\n"
         f"[{expected_statuses[1]}] [{machine2.name}]({benchmarkable.conbench_compare_runs_web_url(machine2)})\n"
+        "Buildkite builds:\n"
+        f"[{expected_build_statuses[0]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine1.name} / builds / 1 | `{test_benchmarkable_id}` {machine1.name} >"
+        f"[{expected_build_statuses[1]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine1.name} / builds / 1 | `{test_baseline_benchmarkable_id}` {machine1.name} >"
+        f"[{expected_build_statuses[2]}] < https: // buildkite.com / apache-arrow / arrow-bci-benchmark-on-{machine2.name} / builds / 1 | `{test_baseline_benchmarkable_id}` {machine2.name} >"
         f"{support_benchmarks_info}\n"
     )
 
@@ -67,22 +71,27 @@ def test_generate_pull_comment_body(client):
         (
             [(benchmarkable.baseline_machine_run(machine1), "finished")],
             [scheduled_status_with_warning, skipped_status],
+            ["Scheduled", "Scheduled", "Scheduled"],
         ),
         (
             [(benchmarkable.machine_run(machine1), "failed")],
             [failed_status, skipped_status],
+            ["Scheduled", "Scheduled", "Scheduled"],
         ),
         (
             [(benchmarkable.machine_run(machine1), "finished")],
             [finished_status, skipped_status],
+            ["Scheduled", "Scheduled", "Scheduled"],
         ),
         (
             [(benchmarkable.baseline_machine_run(machine2), "finished")],
             [finished_status, skipped_status],
+            ["Scheduled", "Scheduled", "Scheduled"],
         ),
         (
             [(benchmarkable.machine_run(machine2), "finished")],
             [finished_status, finished_status],
+            ["Scheduled", "Scheduled", "Scheduled"],
         ),
     ]
     for input_run_statuses, expected_statuses in test_cases:


### PR DESCRIPTION
This PR enables publishing Buildkite build urls to PR comments.
I would like to start 
- asking Apache Arrow contributors for help for issues like `C++ Arrow fails to build` and this will provide them with links to the logs that will enable them to help.
- asking Apache Arrow contributors look at failed builds and confirm that their changes did not break Arrow-Benchmarks-CI or benchmarks.
