### PR TITLE
[WIP] Remove our special duckdb installing

### DIFF
--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -37,7 +37,6 @@ repos_with_benchmark_groups = [
             "Python": ["create_data_dir"],
             "R": [
                 "build_arrow_r",
-                "install_duckdb_r_with_tpch",
                 "install_arrowbench",
                 "create_data_dir",
             ],

--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -106,21 +106,6 @@ install_arrowbench() {
   R -e "remotes::install_local('./arrowbench')"
 }
 
-install_duckdb_r_with_tpch() {
-  git clone https://github.com/duckdb/duckdb.git
-
-  # now fetch the latest tag to install
-  cd duckdb
-  git fetch --tags
-  latestTag=$(git describe --tags `git rev-list --tags --max-count=1`)
-  git checkout $latestTag
-
-  # and then do the install
-  cd tools/rpkg
-  R -e "remotes::install_deps()"
-  DUCKDB_R_EXTENSIONS=tpch R CMD INSTALL .
-}
-
 install_java_script_project_dependencies() {
   pushd $REPO_DIR
   source dev/conbench_envs/hooks.sh install_java_script_project_dependencies

--- a/docs/how-to-add-new-benchmarkable-repo.md
+++ b/docs/how-to-add-new-benchmarkable-repo.md
@@ -53,7 +53,6 @@ Examples of `benchmarks.json` in repos with benchmarks integrated with Conbench:
         "setup_commands_for_lang_benchmarks": {
             "R": [
                 "build_arrow_r",
-                "install_duckdb_r_with_tpch",
                 "install_arrowbench",
                 "create_data_dir",
             ]

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -21,7 +21,6 @@ expected_setup_commands_for_cpp_benchmarks = [
 
 expected_setup_commands_for_r_benchmarks = [
     ("source buildkite/benchmark/utils.sh build_arrow_r", ".", True),
-    ("source buildkite/benchmark/utils.sh install_duckdb_r_with_tpch", ".", True),
     ("source buildkite/benchmark/utils.sh install_arrowbench", ".", True),
     ("source buildkite/benchmark/utils.sh create_data_dir", ".", True),
 ]


### PR DESCRIPTION
We've updated the way that duckdb gets used so that it is only needed to (re)create tpc-h data, and thus should be able to be installed only when that happens.