### PR TITLE
Do not clone arrow repo when installing archery

### DIFF
--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -94,7 +94,6 @@ build_arrow_java() {
 }
 
 install_archery() {
-  clone_repo
   pushd $REPO_DIR
   source dev/conbench_envs/hooks.sh install_archery
   popd


### PR DESCRIPTION
Trying to figure out how to fix test-mac-arm builds