### PR TITLE
Install benchmarks with pip

### DIFF
--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -29,7 +29,7 @@ repos_with_benchmark_groups = [
         "repo": "https://github.com/voltrondata-labs/benchmarks.git",
         "root": "benchmarks",
         "branch": "main",
-        "setup_commands": ["python setup.py develop"],
+        "setup_commands": ["pip install -e ."],
         "path_to_benchmark_groups_list_json": "benchmarks/benchmarks.json",
         "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/benchmarks/main/benchmarks.json",
         "setup_commands_for_lang_benchmarks": {  # These commands need to be defined as functions in buildkite/benchmark/utils.sh

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -12,7 +12,7 @@ from tests.helpers import (
 expected_setup_commands = [
     ("git clone https://github.com/voltrondata-labs/benchmarks.git", ".", True),
     ("git fetch && git checkout main", "benchmarks", True),
-    ("python setup.py develop", "benchmarks", True),
+    ("pip install -e .", "benchmarks", True),
 ]
 
 expected_setup_commands_for_cpp_benchmarks = [


### PR DESCRIPTION
Switches from using `python setup.py develop` ([which is deprecated/discouraged](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html)) for installing `voltrondata-labs/benchmarks` to `pip install -e .`, which is more or less equivalent, but which will let us install from git in our requirements.txt like [this](https://github.com/voltrondata-labs/benchmarks/pull/119/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R4).