### PR TITLE
Added PR number to benchmark build env

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -17,7 +17,11 @@ from models import (  # noqa  # isort:skip
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-sqlalchemy_url = str(engine.url) if engine else Config.SQLALCHEMY_DATABASE_URI
+if engine and "***" not in str(engine.url):
+    sqlalchemy_url = str(engine.url)
+else:
+    sqlalchemy_url = Config.SQLALCHEMY_DATABASE_URI
+
 config.set_main_option("sqlalchemy.url", sqlalchemy_url)
 
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -17,8 +17,9 @@ from models import (  # noqa  # isort:skip
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-if engine and "***" not in str(engine.url):
-    sqlalchemy_url = str(engine.url)
+
+if engine:
+    sqlalchemy_url = engine.url.render_as_string(hide_password=False)
 else:
     sqlalchemy_url = Config.SQLALCHEMY_DATABASE_URI
 

--- a/models/run.py
+++ b/models/run.py
@@ -104,9 +104,15 @@ class Run(Base, BaseMixin):
         return self.reason
 
     def create_benchmark_build(self):
+        if self.benchmarkable.pull_number:
+            pr_number = str(self.benchmarkable.pull_number)
+        else:
+            pr_number = ""
+
         env = {
             "BENCHMARKABLE": self.benchmarkable_id,
             "BENCHMARKABLE_TYPE": self.benchmarkable.type,
+            "BENCHMARKABLE_PR_NUMBER": pr_number,
             "FILTERS": json.dumps(self.filters),
             "MACHINE": self.machine_name,
             "RUN_ID": self.id,


### PR DESCRIPTION
This PR adds the `BENCHMARKABLE_PR_NUMBER` environment variable to benchmark builds, so they may in turn pass that number along to Conbench if it exists.