### PR TITLE
Only provide PR number if it's a PR

### DIFF
--- a/models/run.py
+++ b/models/run.py
@@ -104,7 +104,7 @@ class Run(Base, BaseMixin):
         return self.reason
 
     def create_benchmark_build(self):
-        if self.benchmarkable.pull_number:
+        if self.benchmarkable.pull_number and self.reason == "pull-request":
             pr_number = str(self.benchmarkable.pull_number)
         else:
             pr_number = ""


### PR DESCRIPTION
We should only populate the `BENCHMARKABLE_PR_NUMBER` env var to benchmark builds if the run reason is actually a PR.