### PR TITLE
benchmark utils.sh: pin conbench CLI to 8e5db5c

### DIFF
--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -75,6 +75,9 @@ clone_repo() {
 install_conbench() {
   git clone https://github.com/conbench/conbench.git
   pushd conbench
+  # pin version: make this not be a moving dependency.
+  # The current commit is from January 2023.
+  git checkout 8e5db5c0142f401709396ffdba34fb411640bada
   pip install -r requirements-cli.txt
   pip install -U PyYAML
   python setup.py install


### PR DESCRIPTION
This checks out a specific Conbench repo commit when setting up the (legacy) Conbench CLI.

This removes the typical 'moving target' risk. Sometimes that risk is worth having because one really wants to have an additional sensor for "is something broken?". But if that sensor is an important system that should simply not break, then it's better to not misuse that system for additional testing. In that case we want to version-pin. I think we have such a case here.

Related/motivating tickets:
- https://github.com/conbench/conbench/issues/617
- https://github.com/conbench/conbench/issues/618
- https://github.com/conbench/conbench/pull/616