### PR TITLE
Allow benchmarks with runners beyond conbench CLI

### DIFF
--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -440,7 +440,7 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
             f.write(r_command)
 
         self.executor.execute_command(
-            f"source ~/.bashrc; R --vanilla -f {tmp}",
+            f"R --vanilla -f {tmp}",
             path=self.root,
             exit_on_failure=False,
         )

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -76,11 +76,10 @@ repos_with_benchmark_groups = [
         "benchmarkable_type": "arrow-commit",
         "repo": "https://github.com/voltrondata-labs/arrow-benchmarks-ci.git",
         "root": "arrow-benchmarks-ci/adapters",
-        "branch": "edward/direct-running",  # "main", # TODO: switch back to main
+        "branch": "main",
         "setup_commands": ["pip install -r requirements.txt"],
         "path_to_benchmark_groups_list_json": "arrow-benchmarks-ci/adapters/benchmarks.json",
-        # TODO: point this at main
-        "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/arrow-benchmarks-ci/edward/direct-running/adapters/benchmarks.json",
+        "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/arrow-benchmarks-ci/main/adapters/benchmarks.json",
         "setup_commands_for_lang_benchmarks": {  # These commands need to be defined as functions in buildkite/benchmark/utils.sh
             "C++": ["install_archery"],
             "Python": ["create_data_dir"],

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -406,7 +406,12 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
         Run.print_env_vars()
 
         self.executor.execute_command(
-            "pip install 'benchconnect@git+https://github.com/conbench/conbench.git@main#subdirectory=benchconnect'",
+            "R --vanilla -e 'arrowbench::install_pipx()' && pipx ensurepath",
+            path=self.root,
+            exit_on_failure=True,
+        )
+        self.executor.execute_command(
+            "R --vanilla -e 'arrowbench::install_benchconnect()'",
             path=self.root,
             exit_on_failure=True,
         )

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -57,7 +57,7 @@ repos_with_benchmark_groups = [
         "benchmarkable_type": "arrow-commit",
         "repo": "https://github.com/voltrondata-labs/arrowbench.git",
         "root": "arrowbench",
-        "branch": "edward/json-command-args",  # "main", # TODO: switch back to main after merged
+        "branch": "main",
         "setup_commands": [],
         "path_to_benchmark_groups_list_json": "arrowbench/inst/benchmarks.json",
         "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/arrowbench/main/inst/benchmarks.json",
@@ -408,6 +408,8 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
         bm_df <- arrowbench::get_package_benchmarks();
         arrowbench::run(
             bm_df[bm_df$name %in% c({str(bm_names)[1:-1]}), ],
+            n_iter = 3L,
+            drop_caches = TRUE,
             publish = TRUE,
             run_name = {os.getenv('RUN_NAME')},
             run_reason = {os.getenv('RUN_REASON')}

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -411,7 +411,7 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
             exit_on_failure=True,
         )
         self.executor.execute_command(
-            "R --vanilla -e 'arrowbench::install_benchconnect()'",
+            "R --vanilla -e 'arrowbench::install_benchconnect()' && R --vanilla -e 'stopifnot(arrowbench:::benchconnect_available())'",
             path=self.root,
             exit_on_failure=True,
         )
@@ -445,7 +445,7 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
             f.write(r_command)
 
         self.executor.execute_command(
-            f"R --vanilla -f {tmp}",
+            f"source ~/.bashrc; R --vanilla -f {tmp}",
             path=self.root,
             exit_on_failure=False,
         )

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -57,7 +57,7 @@ repos_with_benchmark_groups = [
         "benchmarkable_type": "arrow-commit",
         "repo": "https://github.com/voltrondata-labs/arrowbench.git",
         "root": "arrowbench",
-        "branch": "main",
+        "branch": "edward/json-command-args",  # "main", # TODO: switch back to main after merged
         "setup_commands": [],
         "path_to_benchmark_groups_list_json": "arrowbench/inst/benchmarks.json",
         "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/arrowbench/main/inst/benchmarks.json",
@@ -69,8 +69,6 @@ repos_with_benchmark_groups = [
             ],
         },
         "env_vars": {
-            "PYTHONFAULTHANDLER": "1",  # makes it easy to debug segmentation faults
-            "BENCHMARKS_DATA_DIR": f"{os.getenv('HOME')}/data",  # allows to avoid loading Python and R benchmarks input data from s3 for every build
             "ARROWBENCH_DATA_DIR": f"{os.getenv('HOME')}/data",  # allows to avoid loading R benchmarks input data from s3 for every build
         },
     },
@@ -94,9 +92,6 @@ repos_with_benchmark_groups = [
             "JavaScript": ["install_java_script_project_dependencies"],
         },
         "env_vars": {
-            "PYTHONFAULTHANDLER": "1",  # makes it easy to debug segmentation faults
-            "BENCHMARKS_DATA_DIR": f"{os.getenv('HOME')}/data",  # allows to avoid loading Python and R benchmarks input data from s3 for every build
-            "ARROWBENCH_DATA_DIR": f"{os.getenv('HOME')}/data",  # allows to avoid loading R benchmarks input data from s3 for every build
             "ARROW_SRC": f"{build_dir}/arrow",  # required by Java Script benchmarks
         },
     },

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -405,6 +405,9 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
         # to disambiguate from labs/benchmarks versions when filtering.
         bm_names = [bm.command for bm in benchmark_groups]
         r_command = f"""
+        arrowbench::install_pipx();
+        arrowbench::install_benchconnect();
+
         bm_df <- arrowbench::get_package_benchmarks();
         arrowbench::run(
             bm_df[bm_df$name %in% c({str(bm_names)[1:-1]}), ],

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -15,6 +15,9 @@ from utils import generate_uuid
 
 from .run_utils import post_logs_to_arrow_bci, run_context
 
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
 benchmark_langs = ["C++", "Java", "Python", "R", "JavaScript", "Rust"]
 benchmarkable_id = os.getenv("BENCHMARKABLE")
 run_id = os.getenv("RUN_ID")
@@ -290,7 +293,7 @@ class BenchmarkGroup:
         if self.mock_run:
             return
 
-        logging.info(self.log_data())
+        log.info(self.log_data())
         post_logs_to_arrow_bci("logs", self.log_data())
 
 
@@ -305,7 +308,7 @@ class CommandExecutor:
         exit_on_failure: bool = True,
         log_stdout: bool = True,
     ):
-        logging.info(f"Started executing -> {command}")
+        log.info(f"Started executing -> {command}")
         self.executed_commands.append((command, path, exit_on_failure))
 
         if log_stdout:
@@ -330,25 +333,25 @@ class CommandExecutor:
             stdout = ""
 
         return_code = result.returncode
-        logging.info(stderr)
-        logging.info(stdout)
+        log.info(stderr)
+        log.info(stdout)
 
         if exit_on_failure and (return_code != 0 or "ERROR" in stderr):
-            logging.error(return_code)
-            logging.error(stderr)
+            log.error(return_code)
+            log.error(stderr)
             raise Exception(f"Failed to execute {command}")
 
         # Always fail the build if benchmark logs have Internal Server Error because
         # it could mean that we are loosing benchmark results because
         # Conbench can't store benchmark results
         if "Internal Server Error" in stdout or "Internal Server Error" in stderr:
-            logging.error(stdout)
-            logging.error(stderr)
+            log.error(stdout)
+            log.error(stderr)
             raise Exception(
                 "Failed to post benchmark results because of Internal Server Error"
             )
 
-        logging.info(f"Done executing -> {command}")
+        log.info(f"Done executing -> {command}")
         return return_code, stderr
 
 
@@ -581,9 +584,9 @@ class Run:
     def print_env_vars():
         for var, value in sorted(os.environ.items()):
             if "PASSWORD" in var or "SECRET" in var or "TOKEN" in var or "PAT" in var:
-                logging.info(f"{var}=[REDACTED]")
+                log.info(f"{var}=[REDACTED]")
             else:
-                logging.info(f"{var}={value}")
+                log.info(f"{var}={value}")
 
     def benchmark_groups_for_lang(self, lang):
         return list(
@@ -647,7 +650,7 @@ class Run:
                 try:
                     self.additional_setup_for_benchmark_groups(lang)
                 except Exception as e:
-                    logging.exception(e)
+                    log.exception(e)
                     stderr = f"Setup for {lang} benchmark groups failed"
                     self.mark_benchmark_groups_failed(lang, stderr)
                     continue
@@ -681,7 +684,7 @@ class MockCommandExecutor(CommandExecutor):
         exit_on_failure: bool = True,
         log_stdout: bool = True,
     ):
-        logging.info(f"Started executing -> {command}")
+        log.info(f"Started executing -> {command}")
         self.executed_commands.append((command, path, exit_on_failure))
         return 0, ""
 

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -411,8 +411,9 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
             n_iter = 3L,
             drop_caches = TRUE,
             publish = TRUE,
-            run_name = {os.getenv('RUN_NAME')},
-            run_reason = {os.getenv('RUN_REASON')}
+            run_id = '{os.getenv('RUN_ID')}',
+            run_name = '{os.getenv('RUN_NAME')}',
+            run_reason = '{os.getenv('RUN_REASON')}'
         )
         """
 

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -406,12 +406,7 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
         Run.print_env_vars()
 
         self.executor.execute_command(
-            "R --vanilla -e 'arrowbench::install_pipx()'",
-            path=self.root,
-            exit_on_failure=True,
-        )
-        self.executor.execute_command(
-            "R --vanilla -e 'arrowbench::install_benchconnect()'",
+            "pip intall 'benchconnect@git+https://github.com/conbench/conbench.git@main#subdirectory=benchconnect'",
             path=self.root,
             exit_on_failure=True,
         )

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -406,12 +406,7 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
         Run.print_env_vars()
 
         self.executor.execute_command(
-            "R --vanilla -e 'arrowbench::install_pipx()' && pipx ensurepath",
-            path=self.root,
-            exit_on_failure=True,
-        )
-        self.executor.execute_command(
-            "R --vanilla -e 'arrowbench::install_benchconnect()' && R --vanilla -e 'stopifnot(arrowbench:::benchconnect_available())'",
+            "pip install 'benchconnect@git+https://github.com/conbench/conbench.git@main#subdirectory=benchconnect' && R --vanilla -e 'stopifnot(arrowbench:::benchconnect_available())'",
             path=self.root,
             exit_on_failure=True,
         )
@@ -424,8 +419,9 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
         bm_names <- c({str(bm_names)[1:-1]})
         bm_df_filtered <- bm_df[bm_df$name %in% bm_names, ]
 
-        print(paste('Benchmark names to run:', toString(bm_names)))
-        print('Benchmark dataframe run:')
+        # Benchmark names to run:
+        print(bm_names)
+        # Benchmark dataframe to run:
         print(bm_df_filtered)
 
         arrowbench::run(

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -406,7 +406,7 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
         Run.print_env_vars()
 
         self.executor.execute_command(
-            "pip intall 'benchconnect@git+https://github.com/conbench/conbench.git@main#subdirectory=benchconnect'",
+            "pip install 'benchconnect@git+https://github.com/conbench/conbench.git@main#subdirectory=benchconnect'",
             path=self.root,
             exit_on_failure=True,
         )

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -78,8 +78,9 @@ repos_with_benchmark_groups = [
         "root": "arrow-benchmarks-ci/adapters",
         "branch": "edward/direct-running",  # "main", # TODO: switch back to main
         "setup_commands": ["pip install -r requirements.txt"],
-        "path_to_benchmark_groups_list_json": "arrowbench/inst/benchmarks.json",
-        "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/arrowbench/main/inst/benchmarks.json",
+        "path_to_benchmark_groups_list_json": "arrow-benchmarks-ci/adapters/benchmarks.json",
+        # TODO: point this at main
+        "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/arrow-benchmarks-ci/edward/direct-running/adapters/benchmarks.json",
         "setup_commands_for_lang_benchmarks": {  # These commands need to be defined as functions in buildkite/benchmark/utils.sh
             "C++": ["install_archery"],
             "Python": ["create_data_dir"],

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -429,7 +429,6 @@ class ArrowbenchBenchmarkGroupsRunner(BenchmarkGroupsRunner):
             n_iter = 3L,
             drop_caches = TRUE,
             publish = TRUE,
-            run_id = '{os.getenv('RUN_ID')}',
             run_name = '{os.getenv('RUN_NAME')}',
             run_reason = '{os.getenv('RUN_REASON')}'
         )

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -471,7 +471,9 @@ class Run:
         if os.getenv("REPO") == self.repo:
             return
 
-        self.executor.execute_command(f"git clone {self.repo}")
+        if not Path(self.root).exists():
+            self.executor.execute_command(f"git clone {self.repo}")
+
         self.executor.execute_command(
             f"git fetch && git checkout {self.branch}", self.root
         )

--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -106,7 +106,6 @@ install_archery() {
 
 install_arrowbench() {
   # do I need to cd into benchmarks dir?
-  rm -rf arrowbench
   git clone https://github.com/voltrondata-labs/arrowbench.git
   R -e "remotes::install_local('./arrowbench')"
 }

--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -6,7 +6,7 @@ init_conda() {
 
 create_conda_env_for_arrow_commit() {
   pushd $REPO_DIR
-  
+
   conda create -y -n "${BENCHMARKABLE_TYPE}" -c conda-forge \
   --file ci/conda_env_unix.txt \
   --file ci/conda_env_cpp.txt \
@@ -18,19 +18,19 @@ create_conda_env_for_arrow_commit() {
 
   source dev/conbench_envs/hooks.sh activate_conda_env_for_benchmark_build
   source dev/conbench_envs/hooks.sh install_arrow_python_dependencies
-  
+
   # Workaround for https://github.com/aws/aws-sdk-cpp/issues/1820
   conda install -y -c conda-forge cmake==3.21.3
-  
+
   # Archery does not work when using setuptools==60.9.0
   conda install -y -c conda-forge setuptools==58.0.4
-  
+
   source dev/conbench_envs/hooks.sh set_arrow_build_and_run_env_vars
 
   export RANLIB=`which $RANLIB`
   export AR=`which $AR`
   export ARROW_JEMALLOC=OFF
-  
+
   source dev/conbench_envs/hooks.sh build_arrow_cpp
   source dev/conbench_envs/hooks.sh build_arrow_python
   popd
@@ -106,6 +106,7 @@ install_archery() {
 
 install_arrowbench() {
   # do I need to cd into benchmarks dir?
+  rm -rf arrowbench
   git clone https://github.com/voltrondata-labs/arrowbench.git
   R -e "remotes::install_local('./arrowbench')"
 }

--- a/config.py
+++ b/config.py
@@ -199,13 +199,9 @@ class Config:
             "default_filters": {
                 "arrow-commit": {
                     "langs": {
-                        "Python": {
-                            "names": ["adapters/mock-adapter"]
-                        },  # {"names": ["dataset-read", "dataset-select"]},
-                        # "C++": {"names": ["cpp-micro"]},
-                        "R": {
-                            "names": ["file-write", "arrowbench/file-write"]  # "tpch",
-                        },
+                        "Python": {"names": ["dataset-read", "dataset-select"]},
+                        "C++": {"names": ["cpp-micro"]},
+                        "R": {"names": ["tpch"]},
                     }
                 },
             },

--- a/config.py
+++ b/config.py
@@ -199,7 +199,9 @@ class Config:
             "default_filters": {
                 "arrow-commit": {
                     "langs": {
-                        # "Python": {"names": ["dataset-read", "dataset-select"]},
+                        "Python": [
+                            "adapters/mock-adapter"
+                        ],  # {"names": ["dataset-read", "dataset-select"]},
                         # "C++": {"names": ["cpp-micro"]},
                         "R": {
                             "names": ["file-write", "arrowbench/file-write"]  # "tpch",

--- a/config.py
+++ b/config.py
@@ -201,7 +201,7 @@ class Config:
                     "langs": {
                         "Python": {"names": ["dataset-read", "dataset-select"]},
                         "C++": {"names": ["cpp-micro"]},
-                        "R": {"names": ["tpch"]},
+                        "R": {"names": ["tpch", "arrowbench/file-write"]},
                     }
                 },
             },

--- a/config.py
+++ b/config.py
@@ -200,7 +200,7 @@ class Config:
                 "arrow-commit": {
                     "langs": {
                         "Python": {"names": ["dataset-read", "dataset-select"]},
-                        "C++": {"names": ["cpp-micro"]},
+                        # "C++": {"names": ["cpp-micro"]},
                         "R": {"names": ["tpch", "arrowbench/file-write"]},
                     }
                 },

--- a/config.py
+++ b/config.py
@@ -199,9 +199,9 @@ class Config:
             "default_filters": {
                 "arrow-commit": {
                     "langs": {
-                        "Python": [
-                            "adapters/mock-adapter"
-                        ],  # {"names": ["dataset-read", "dataset-select"]},
+                        "Python": {
+                            "names": ["adapters/mock-adapter"]
+                        },  # {"names": ["dataset-read", "dataset-select"]},
                         # "C++": {"names": ["cpp-micro"]},
                         "R": {
                             "names": ["file-write", "arrowbench/file-write"]  # "tpch",

--- a/config.py
+++ b/config.py
@@ -201,7 +201,9 @@ class Config:
                     "langs": {
                         "Python": {"names": ["dataset-read", "dataset-select"]},
                         # "C++": {"names": ["cpp-micro"]},
-                        "R": {"names": ["tpch", "arrowbench/file-write"]},
+                        "R": {
+                            "names": ["file-write", "arrowbench/file-write"]  # "tpch",
+                        },
                     }
                 },
             },

--- a/config.py
+++ b/config.py
@@ -199,7 +199,7 @@ class Config:
             "default_filters": {
                 "arrow-commit": {
                     "langs": {
-                        "Python": {"names": ["dataset-read", "dataset-select"]},
+                        # "Python": {"names": ["dataset-read", "dataset-select"]},
                         # "C++": {"names": ["cpp-micro"]},
                         "R": {
                             "names": ["file-write", "arrowbench/file-write"]  # "tpch",

--- a/models/machine.py
+++ b/models/machine.py
@@ -103,16 +103,19 @@ class Machine(Base, BaseMixin):
                     ]
                 machine_run_filters["langs"][lang]["names"] = filtered_benchmark_names
 
+        has_groups = False
         for repo_with_benchmark_groups in repos_with_benchmark_groups:
             if repo_with_benchmark_groups["benchmarkable_type"] == benchmarkable_type:
                 mock_run = MockRun(
                     repo_with_benchmark_groups, filters=machine_run_filters
                 )
-                if not mock_run.has_benchmark_groups_to_execute():
-                    return (
-                        machine_run_filters,
-                        f"Provided benchmark filters do not have any benchmark groups to be executed on {self.name}",
-                    )
+                has_groups = has_groups or mock_run.has_benchmark_groups_to_execute()
+
+        if not has_groups:
+            return (
+                machine_run_filters,
+                f"Provided benchmark filters do not have any benchmark groups to be executed on {self.name}",
+            )
 
         return machine_run_filters, None
 

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -203,7 +203,11 @@ tests = [
 
 
 def test_run_benchmarks():
-    repo = deepcopy(repos_with_benchmark_groups[0])
+    repo = [
+        deepcopy(x)
+        for x in repos_with_benchmark_groups
+        if x["repo"].endswith("voltrondata-labs/benchmarks.git")
+    ][0]
     # These tests should use benchmarks.json in benchmarks repo but should not be affected any new benchmarks
     # that added since 2b217db086260ab3bb243e26253b7c1de0180777
     repo[
@@ -218,7 +222,11 @@ def test_run_benchmarks():
 
 
 def test_run_arrowbench_benchmarks():
-    repo = deepcopy(repos_with_benchmark_groups[1])
+    repo = [
+        deepcopy(x)
+        for x in repos_with_benchmark_groups
+        if x["repo"].endswith("arrowbench.git")
+    ][0]
     # These tests should use benchmarks.json in arrowbench repo but should not be affected any new benchmarks
     # that added since c5e5af241f17d27aadc01548f283a2a977151b91
     repo[
@@ -246,7 +254,7 @@ def test_run_arrowbench_benchmarks():
     assert run_command[0].endswith(".R")
     assert run_command[1] == "arrowbench"
     assert run_command[2] is False
-    tempfile_path = Path(run_command[0].split()[2])
+    tempfile_path = Path(run_command[0].split()[2]).resolve()
     with open(tempfile_path, "r") as f:
         tempfile_lines = [line.strip() for line in f.readlines()]
 
@@ -266,7 +274,11 @@ def test_run_arrowbench_benchmarks():
 
 
 def test_run_adapter_benchmarks():
-    repo = deepcopy(repos_with_benchmark_groups[2])
+    repo = [
+        deepcopy(x)
+        for x in repos_with_benchmark_groups
+        if x["repo"].endswith("arrow-benchmarks-ci.git")
+    ][0]
     # These tests should use benchmarks.json in arrow-benchmarks-ci repo but should not be affected any new benchmarks
     # that added since 1ca33e8800a11624faf89a85af817ca83e473f56
     repo[

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -267,7 +267,7 @@ def test_run_arrowbench_benchmarks(monkeypatch):
     assert run.executor.executed_commands[:-1] == expected_setup_commands
     run_command = run.executor.executed_commands[-1]
     # runs an ephemeral tempfile
-    assert run_command[0].startswith("source ~/.bashrc; R --vanilla -f ")
+    assert run_command[0].startswith("R --vanilla -f ")
     assert run_command[0].endswith(".R")
     assert run_command[1] == "arrowbench"
     assert run_command[2] is False

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -254,12 +254,7 @@ def test_run_arrowbench_benchmarks(monkeypatch):
         + expected_setup_commands_for_r_benchmarks
         + [
             (
-                "R --vanilla -e 'arrowbench::install_pipx()' && pipx ensurepath",
-                "arrowbench",
-                True,
-            ),
-            (
-                "R --vanilla -e 'arrowbench::install_benchconnect()' && R --vanilla -e 'stopifnot(arrowbench:::benchconnect_available())'",
+                "pip install 'benchconnect@git+https://github.com/conbench/conbench.git@main#subdirectory=benchconnect' && R --vanilla -e 'stopifnot(arrowbench:::benchconnect_available())'",
                 "arrowbench",
                 True,
             ),
@@ -287,8 +282,9 @@ def test_run_arrowbench_benchmarks(monkeypatch):
         "'partitioned-dataset-filter', 'file-read')",
         "bm_df_filtered <- bm_df[bm_df$name %in% bm_names, ]",
         "",
-        "print(paste('Benchmark names to run:', toString(bm_names)))",
-        "print('Benchmark dataframe run:')",
+        "# Benchmark names to run:",
+        "print(bm_names)",
+        "# Benchmark dataframe to run:",
         "print(bm_df_filtered)",
         "",
         "arrowbench::run(",

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -292,7 +292,6 @@ def test_run_arrowbench_benchmarks(monkeypatch):
         "n_iter = 3L,",
         "drop_caches = TRUE,",
         "publish = TRUE,",
-        f"run_id = '{run_id}',",
         f"run_name = '{run_name}',",
         f"run_reason = '{run_reason}'",
         ")",

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -253,8 +253,11 @@ def test_run_arrowbench_benchmarks(monkeypatch):
         ]
         + expected_setup_commands_for_r_benchmarks
         + [
-            ("R --vanilla -e 'arrowbench::install_pipx()'", "arrowbench", True),
-            ("R --vanilla -e 'arrowbench::install_benchconnect()'", "arrowbench", True),
+            (
+                "pip intall 'benchconnect@git+https://github.com/conbench/conbench.git@main#subdirectory=benchconnect'",
+                "arrowbench",
+                True,
+            ),
         ]
     )
 

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -263,6 +263,8 @@ def test_run_arrowbench_benchmarks():
         "bm_df <- arrowbench::get_package_benchmarks();",
         "arrowbench::run(",
         "bm_df[bm_df$name %in% c('file-write', 'dataframe-to-table', 'partitioned-dataset-filter', 'file-read'), ],",
+        "n_iter = 3L,",
+        "drop_caches = TRUE,",
         "publish = TRUE,",
         "run_name = None,",
         "run_reason = None",

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -254,10 +254,11 @@ def test_run_arrowbench_benchmarks(monkeypatch):
         + expected_setup_commands_for_r_benchmarks
         + [
             (
-                "pip install 'benchconnect@git+https://github.com/conbench/conbench.git@main#subdirectory=benchconnect'",
+                "R --vanilla -e 'arrowbench::install_pipx()' && pipx ensurepath",
                 "arrowbench",
                 True,
             ),
+            ("R --vanilla -e 'arrowbench::install_benchconnect()'", "arrowbench", True),
         ]
     )
 

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -254,7 +254,7 @@ def test_run_arrowbench_benchmarks(monkeypatch):
         + expected_setup_commands_for_r_benchmarks
         + [
             (
-                "pip intall 'benchconnect@git+https://github.com/conbench/conbench.git@main#subdirectory=benchconnect'",
+                "pip install 'benchconnect@git+https://github.com/conbench/conbench.git@main#subdirectory=benchconnect'",
                 "arrowbench",
                 True,
             ),

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -266,12 +266,12 @@ def test_run_arrowbench_benchmarks():
 
 
 def test_run_adapter_benchmarks():
-    repo = deepcopy(repos_with_benchmark_groups[1])
-    # # These tests should use benchmarks.json in arrow-benchmarks-ci repo but should not be affected any new benchmarks
-    # # that added since c5e5af241f17d27aadc01548f283a2a977151b91
-    # repo[
-    #     "url_for_benchmark_groups_list_json"
-    # ] = "https://raw.githubusercontent.com/voltrondata-labs/arrow-benchmarks-ci/c5e5af241f17d27aadc01548f283a2a977151b91/adapters/benchmarks.json"
+    repo = deepcopy(repos_with_benchmark_groups[2])
+    # These tests should use benchmarks.json in arrow-benchmarks-ci repo but should not be affected any new benchmarks
+    # that added since 1ca33e8800a11624faf89a85af817ca83e473f56
+    repo[
+        "url_for_benchmark_groups_list_json"
+    ] = "https://raw.githubusercontent.com/voltrondata-labs/arrow-benchmarks-ci/1ca33e8800a11624faf89a85af817ca83e473f56/adapters/benchmarks.json"
 
     filters = {
         "langs": {
@@ -289,8 +289,13 @@ def test_run_adapter_benchmarks():
             ".",
             True,
         ),
-        ("git fetch && git checkout main", "arrow-benchmarks-ci/adapters", True),
+        (
+            "git fetch && git checkout edward/direct-running",
+            "arrow-benchmarks-ci/adapters",
+            True,
+        ),
         ("pip install -r requirements.txt", "arrow-benchmarks-ci/adapters", True),
+        ("source buildkite/benchmark/utils.sh create_data_dir", ".", True),
     ]
 
     expected_run_commands = [

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -267,6 +267,9 @@ def test_run_arrowbench_benchmarks(monkeypatch):
 
     assert tempfile_lines == [
         "",
+        "arrowbench::install_pipx();",
+        "arrowbench::install_benchconnect();",
+        "",
         "bm_df <- arrowbench::get_package_benchmarks();",
         "arrowbench::run(",
         "bm_df[bm_df$name %in% c('file-write', 'dataframe-to-table', 'partitioned-dataset-filter', 'file-read'), ],",

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -315,7 +315,7 @@ def test_run_adapter_benchmarks():
             True,
         ),
         (
-            "git fetch && git checkout edward/direct-running",
+            "git fetch && git checkout main",
             "arrow-benchmarks-ci/adapters",
             True,
         ),

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -221,7 +221,14 @@ def test_run_benchmarks():
         assert run.executor.executed_commands == test["expected_commands"]
 
 
-def test_run_arrowbench_benchmarks():
+def test_run_arrowbench_benchmarks(monkeypatch):
+    run_id = "fake-run-id"
+    run_name = "test-run-name"
+    run_reason = "test"
+    monkeypatch.setenv("RUN_ID", run_id)
+    monkeypatch.setenv("RUN_NAME", run_name)
+    monkeypatch.setenv("RUN_REASON", run_reason)
+
     repo = [
         deepcopy(x)
         for x in repos_with_benchmark_groups
@@ -266,8 +273,9 @@ def test_run_arrowbench_benchmarks():
         "n_iter = 3L,",
         "drop_caches = TRUE,",
         "publish = TRUE,",
-        "run_name = None,",
-        "run_reason = None",
+        f"run_id = '{run_id}',",
+        f"run_name = '{run_name}',",
+        f"run_reason = '{run_reason}'",
         ")",
         "",
     ]

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -258,7 +258,11 @@ def test_run_arrowbench_benchmarks(monkeypatch):
                 "arrowbench",
                 True,
             ),
-            ("R --vanilla -e 'arrowbench::install_benchconnect()'", "arrowbench", True),
+            (
+                "R --vanilla -e 'arrowbench::install_benchconnect()' && R --vanilla -e 'stopifnot(arrowbench:::benchconnect_available())'",
+                "arrowbench",
+                True,
+            ),
         ]
     )
 
@@ -268,11 +272,11 @@ def test_run_arrowbench_benchmarks(monkeypatch):
     assert run.executor.executed_commands[:-1] == expected_setup_commands
     run_command = run.executor.executed_commands[-1]
     # runs an ephemeral tempfile
-    assert run_command[0].startswith("R --vanilla -f ")
+    assert run_command[0].startswith("source ~/.bashrc; R --vanilla -f ")
     assert run_command[0].endswith(".R")
     assert run_command[1] == "arrowbench"
     assert run_command[2] is False
-    tempfile_path = Path(run_command[0].split()[3]).resolve()
+    tempfile_path = Path(run_command[0].split()[-1]).resolve()
     with open(tempfile_path, "r") as f:
         tempfile_lines = [line.strip() for line in f.readlines()]
 


### PR DESCRIPTION
Closes #97. 

Relaxes the assumption that all benchmarks will be run with the `conbench` CLI. Also relaxes the assumption that a benchmarkable repo will always have only one benchmarks repo. Adds changes to allow running via arrowbench or adapters.

Notably does not yet turn on arrowbench (or adapter) benchmarks by changing `config.py`, but that change is all that should be required to do so. There are some differences between running via arrowbench instead of labs/benchmarks, though, specifically cache clearing (which https://github.com/voltrondata-labs/arrowbench/issues/126 will fix) and `tags["cpu_count"]`, which labs/benchmarks does not populate, but arrowbench does, so we'll need to clean up the db to unbreak histories. Full details: https://github.com/voltrondata-labs/benchmarks/issues/130

Generally tries to change as little as possible so existing things keep working. 

Specific changes:

1. Changes `run.py`:
    1. Separates abstract `BenchmarkGroupsRunner` class out of the `Run` class. Moves the existing functionality to a `ConbenchBenchmarkGroupsRunner`, but also implements `ArrowbenchBenchmarkGroupsRunner` and `AdapterBenchmarkGroupsRunner`.
        1. arrowbench running notably calls arrowbench once for all benchmarks instead of once each, which allows arrowbench to manage the run. This has two implications: 
            1. The memory monitoring in `BenchmarkGroup` will not represent each neatly in the db anymore.
            2. arrowbench benchmarks cannot be run in the same run as other benchmarks, because they need their own new `run_id`, because they will open and close the run, and other results attempting to submit to the same run will fail to post.
    1. Allows runner to be switched by benchmark JSON (the one that lives in the benchmark repo). Also loosens assumptions about `command` and adds optional `name` so it does not need to be parsed out of `command`. Documents schema. All new fields are optional and everything defaults to the conbench runner, so existing metadata will continue to function without changes.
    1. Separates `CommandExecutor` class out of `Run` so it can be injected into the groups runner class.
    1. Adds arrowbench and new adapters dir (see 2) to `repos_with_benchmark_groups`
1. Adds top-level `adapters` directory with `requirements.txt`, `benchmarks.json` metadata, and `mock-adapter.py`. For now, this is all just the stuff we'll need to run real adapter here, but no real benchmarks, as all of those will require a lot of alterations to run here. The new stuff here will likely need some light tweaks (e.g. ensure dependencies get installed correctly), but this structure shows we can run adapters from here.
1. Adds tests for arrowbench and adapter running. The adapter one will need small changes to run from main instead of this branch, but is currently set up so CI here should work.