### PR TITLE
Only use z-score < -10 threshold for alerts

### DIFF
--- a/models/benchmarkable.py
+++ b/models/benchmarkable.py
@@ -271,11 +271,8 @@ class Benchmarkable(Base, BaseMixin):
             if not results:
                 continue
 
-            # Check if run has at least one benchmark with z-score < -10.0 or
-            # sum of all run's benchmarks z-scores < -200.00
-            if [r for r in results if r["contender_z_score"] < -10.0] or sum(
-                [r["contender_z_score"] for r in results if r["contender_z_score"] < 0]
-            ) < -200.00:
+            # Check if run has at least one benchmark with z-score < -10.0
+            if [r for r in results if r["contender_z_score"] < -10.0]:
                 runs.append(run)
 
         return runs


### PR DESCRIPTION
We used to also sum all the z-scores to detect many small changes. But without a more fine-grained approach that is alerting more than we want. 

This work is temporary (though still important to just get done now) since we will soon be switching to [benchalerts](https://github.com/conbench/conbench/tree/main/benchalerts)