### PR TITLE
bump version of conbench CLI

### DIFF
--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -73,15 +73,7 @@ clone_repo() {
 }
 
 install_conbench() {
-  git clone https://github.com/conbench/conbench.git
-  pushd conbench
-  # pin version: make this not be a moving dependency.
-  # The current commit is from January 2023.
-  git checkout 8e5db5c0142f401709396ffdba34fb411640bada
-  pip install -r requirements-cli.txt
-  pip install -U PyYAML
-  python setup.py install
-  popd
+  pip install 'conbench==2023.4.5'
 }
 
 build_arrow_r() {


### PR DESCRIPTION
This PR bumps the version of the `conbench` CLI to account for small bugfixes including https://github.com/conbench/conbench/pull/1048.