### PR TITLE
Add a machine ignore list to our high regression alerts

### DIFF
--- a/buildkite/schedule_and_publish/publish_benchmark_alerts_on_pull_requests.py
+++ b/buildkite/schedule_and_publish/publish_benchmark_alerts_on_pull_requests.py
@@ -20,7 +20,8 @@ def publish_benchmark_alerts_on_pull_requests():
 
         comment_body = (
             notification.generate_pull_comment_body_for_high_regression_alert(
-                benchmark_langs_filter=["Python", "R"]
+                benchmark_langs_filter=["Python", "R"],
+                benchmark_machine_ignorelist=["test-mac-arm"]
             )
         )
         if comment_body:

--- a/models/benchmarkable.py
+++ b/models/benchmarkable.py
@@ -260,7 +260,7 @@ class Benchmarkable(Base, BaseMixin):
 
         return regressions, improvements
 
-    def runs_with_high_regressions(self, benchmark_langs_filter):
+    def runs_with_high_regressions(self, benchmark_langs_filter, benchmark_machine_ignorelist):
         runs = []
         for run in self.runs_with_buildkite_builds_and_publishable_benchmark_results:
             try:
@@ -271,6 +271,10 @@ class Benchmarkable(Base, BaseMixin):
                 continue
             except Exception as e:
                 raise e
+
+            # skip if this is a machine we ignore
+            if run.machine.name in benchmark_machine_ignorelist:
+                continue
 
             results = [
                 r

--- a/models/notification.py
+++ b/models/notification.py
@@ -92,9 +92,9 @@ class Notification(Base, BaseMixin):
         )
 
     def generate_pull_comment_body_for_high_regression_alert(
-        self, benchmark_langs_filter
+        self, benchmark_langs_filter, benchmark_machine_ignorelist
     ):
-        runs = self.benchmarkable.runs_with_high_regressions(benchmark_langs_filter)
+        runs = self.benchmarkable.runs_with_high_regressions(benchmark_langs_filter, benchmark_machine_ignorelist)
         if not runs:
             return
 


### PR DESCRIPTION
And specifically, don't alert on test-mac-arm machine: we see _a bunch_ of regressions there, many of which seem like pure noise. Likely this is due to the underlying benchmarks being either poorly setup or poorly executed, which should be investigated, but right now the alerts are more noise than they are help IMO.