### PR TITLE
Decommission voltrondata-pavilion machine until we can bring it back

### DIFF
--- a/config.py
+++ b/config.py
@@ -230,12 +230,4 @@ class Config:
             "publish_benchmark_results": False,
             "max_builds": 2,
         },
-        "voltron-pavilion": {
-            "info": "Supported benchmark langs: Python, R, JavaScript, C++, Java",
-            "default_filters": {"arrow-commit": {"langs": {"R": {"names": ["tpch"]}}}},
-            "supported_filters": ["lang", "name"],
-            "offline_warning_enabled": True,
-            "publish_benchmark_results": False,
-            "max_builds": 1,
-        },
     }


### PR DESCRIPTION
`voltrondata-pavilion` is offline and I have no way to bring it back at the moment. I have to decommission this machine until it is  possible to bring it back.