### PR TITLE
Update compare endpoint result subsetting

### DIFF
--- a/models/benchmarkable.py
+++ b/models/benchmarkable.py
@@ -62,7 +62,7 @@ class Benchmarkable(Base, BaseMixin):
     def displayable_message(self):
         if self.is_commit():
             # Remove % since they cause JSON parsing issues when passed to buildkite.
-            # TODO: are there other characters we should also check? And is it possible 
+            # TODO: are there other characters we should also check? And is it possible
             # to escape instead of deleting?
             return self.data["commit"]["message"].splitlines()[0][:60].replace("%", "")
 
@@ -249,13 +249,25 @@ class Benchmarkable(Base, BaseMixin):
             return 0, 0
 
         regressions = round(
-            len([r for r in results if r["contender_z_regression"]])
+            len(
+                [
+                    r
+                    for r in results
+                    if r["analysis"]["lookback_z_score"]["regression_indicated"]
+                ]
+            )
             / len(results)
             * 100,
             2,
         )
         improvements = round(
-            len([r for r in results if r["contender_z_improvement"]])
+            len(
+                [
+                    r
+                    for r in results
+                    if r["analysis"]["lookback_z_score"]["improvement_indicated"]
+                ]
+            )
             / len(results)
             * 100,
             2,
@@ -263,7 +275,9 @@ class Benchmarkable(Base, BaseMixin):
 
         return regressions, improvements
 
-    def runs_with_high_regressions(self, benchmark_langs_filter, benchmark_machine_ignorelist):
+    def runs_with_high_regressions(
+        self, benchmark_langs_filter, benchmark_machine_ignorelist
+    ):
         runs = []
         for run in self.runs_with_buildkite_builds_and_publishable_benchmark_results:
             try:
@@ -282,13 +296,18 @@ class Benchmarkable(Base, BaseMixin):
             results = [
                 r
                 for r in results
-                if r["language"] in benchmark_langs_filter and r["contender_z_score"]
+                if r["contender"]["language"] in benchmark_langs_filter
+                and r["analysis"]["lookback_z_score"]["z_score"]
             ]
             if not results:
                 continue
 
             # Check if run has at least one benchmark with z-score < -30.0
-            if [r for r in results if r["contender_z_score"] < -30.0]:
+            if [
+                r
+                for r in results
+                if r["analysis"]["lookback_z_score"]["z_score"] < -30.0
+            ]:
                 runs.append(run)
 
         return runs

--- a/tests/mocked_integrations/conbench/get_compare_runs.json
+++ b/tests/mocked_integrations/conbench/get_compare_runs.json
@@ -1,59 +1,122 @@
 [
   {
-    "baseline": "10.459 s",
-    "baseline_batch_id": "batch1",
-    "baseline_id": "sha1",
-    "baseline_run_id": 1,
-    "batch": "file-write",
-    "benchmark": "benchmark 1",
-    "change": "0.659%",
-    "contender": "10.528 s",
-    "contender_batch_id": "batch2",
-    "contender_id": "sha2",
-    "contender_run_id": 2,
-    "contender_z_improvement": true,
-    "less_is_better": true,
-    "contender_z_regression": false,
     "unit": "s",
-    "language": "Python",
-    "contender_z_score": 0
+    "less_is_better": true,
+    "baseline": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 1",
+      "language": "Python",
+      "value": 10.459,
+      "error": false,
+      "benchmark_result_id": "sha1",
+      "batch_id": "batch1",
+      "run_id": 1,
+      "tags": []
+    },
+    "contender": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 1",
+      "language": "Python",
+      "value": 10.528,
+      "error": false,
+      "benchmark_result_id": "sha2",
+      "batch_id": "batch2",
+      "run_id": 2,
+      "tags": []
+    },
+    "analysis": {
+      "pairwise": {
+        "percent_change": 0.659,
+        "percent_threshold": 5.0,
+        "regression_indicated": false,
+        "improvement_indicated": false
+      },
+      "lookback_z_score": {
+        "z_threshold": 5.0,
+        "z_score": 0,
+        "regression_indicated": false,
+        "improvement_indicated": true
+      }
+    }
   },
   {
-    "baseline": "10.459 s",
-    "baseline_batch_id": "batch1",
-    "baseline_id": "sha1",
-    "baseline_run_id": 1,
-    "batch": "file-write",
-    "benchmark": "benchmark 2",
-    "change": "0.659%",
-    "contender": "10.528 s",
-    "contender_batch_id": "batch2",
-    "contender_id": "sha2",
-    "contender_run_id": 2,
-    "contender_z_improvement": false,
-    "less_is_better": true,
-    "contender_z_regression": true,
     "unit": "s",
-    "language": "R",
-    "contender_z_score": -0.1
+    "less_is_better": true,
+    "baseline": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 2",
+      "language": "R",
+      "value": 10.459,
+      "error": false,
+      "benchmark_result_id": "sha1",
+      "batch_id": "batch1",
+      "run_id": 1,
+      "tags": []
+    },
+    "contender": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 2",
+      "language": "R",
+      "value": 10.528,
+      "error": false,
+      "benchmark_result_id": "sha2",
+      "batch_id": "batch2",
+      "run_id": 2,
+      "tags": []
+    },
+    "analysis": {
+      "pairwise": {
+        "percent_change": 0.659,
+        "percent_threshold": 5.0,
+        "regression_indicated": false,
+        "improvement_indicated": false
+      },
+      "lookback_z_score": {
+        "z_threshold": 5.0,
+        "z_score": -0.1,
+        "regression_indicated": true,
+        "improvement_indicated": false
+      }
+    }
   },
   {
-    "baseline": "10.459 s",
-    "baseline_batch_id": "batch1",
-    "baseline_id": "sha1",
-    "baseline_run_id": 1,
-    "batch": "file-write",
-    "benchmark": "benchmark 3",
-    "change": "0.659%",
-    "contender": "10.528 s",
-    "contender_batch_id": "batch2",
-    "contender_id": "sha2",
-    "contender_run_id": 2,
-    "contender_z_improvement": false,
-    "less_is_better": true,
-    "contender_z_regression": false,
     "unit": "s",
-    "language": "Python",
-    "contender_z_score": 0
+    "less_is_better": true,
+    "baseline": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 3",
+      "language": "Python",
+      "value": 10.459,
+      "error": false,
+      "benchmark_result_id": "sha1",
+      "batch_id": "batch1",
+      "run_id": 1,
+      "tags": []
+    },
+    "contender": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 3",
+      "language": "Python",
+      "value": 10.528,
+      "error": false,
+      "benchmark_result_id": "sha2",
+      "batch_id": "batch2",
+      "run_id": 2,
+      "tags": []
+    },
+    "analysis": {
+      "pairwise": {
+        "percent_change": 0.659,
+        "percent_threshold": 5.0,
+        "regression_indicated": false,
+        "improvement_indicated": false
+      },
+      "lookback_z_score": {
+        "z_threshold": 5.0,
+        "z_score": 0,
+        "regression_indicated": false,
+        "improvement_indicated": false
+      }
+    }
   }
 ]

--- a/tests/mocked_integrations/conbench/get_compare_runs_high_level_of_regressions.json
+++ b/tests/mocked_integrations/conbench/get_compare_runs_high_level_of_regressions.json
@@ -1,59 +1,122 @@
 [
   {
-    "baseline": "10.459 s",
-    "baseline_batch_id": "batch1",
-    "baseline_id": "sha1",
-    "baseline_run_id": 1,
-    "batch": "file-write",
-    "benchmark": "benchmark 1",
-    "change": "0.659%",
-    "contender": "10.528 s",
-    "contender_batch_id": "batch2",
-    "contender_id": "sha2",
-    "contender_run_id": 2,
-    "contender_z_improvement": true,
-    "less_is_better": true,
-    "contender_z_regression": false,
     "unit": "s",
-    "language": "Python",
-    "contender_z_score": -200.00
+    "less_is_better": true,
+    "baseline": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 1",
+      "language": "Python",
+      "value": 10.459,
+      "error": false,
+      "benchmark_result_id": "sha1",
+      "batch_id": "batch1",
+      "run_id": 1,
+      "tags": []
+    },
+    "contender": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 1",
+      "language": "Python",
+      "value": 10.528,
+      "error": false,
+      "benchmark_result_id": "sha2",
+      "batch_id": "batch2",
+      "run_id": 2,
+      "tags": []
+    },
+    "analysis": {
+      "pairwise": {
+        "percent_change": 0.659,
+        "percent_threshold": 5.0,
+        "regression_indicated": false,
+        "improvement_indicated": false
+      },
+      "lookback_z_score": {
+        "z_threshold": 5.0,
+        "z_score": -200.0,
+        "regression_indicated": false,
+        "improvement_indicated": true
+      }
+    }
   },
   {
-    "baseline": "10.459 s",
-    "baseline_batch_id": "batch1",
-    "baseline_id": "sha1",
-    "baseline_run_id": 1,
-    "batch": "file-write",
-    "benchmark": "benchmark 2",
-    "change": "0.659%",
-    "contender": "10.528 s",
-    "contender_batch_id": "batch2",
-    "contender_id": "sha2",
-    "contender_run_id": 2,
-    "contender_z_improvement": false,
-    "less_is_better": true,
-    "contender_z_regression": true,
     "unit": "s",
-    "language": "Python",
-    "contender_z_score": -200.00
+    "less_is_better": true,
+    "baseline": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 2",
+      "language": "Python",
+      "value": 10.459,
+      "error": false,
+      "benchmark_result_id": "sha1",
+      "batch_id": "batch1",
+      "run_id": 1,
+      "tags": []
+    },
+    "contender": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 2",
+      "language": "Python",
+      "value": 10.528,
+      "error": false,
+      "benchmark_result_id": "sha2",
+      "batch_id": "batch2",
+      "run_id": 2,
+      "tags": []
+    },
+    "analysis": {
+      "pairwise": {
+        "percent_change": 0.659,
+        "percent_threshold": 5.0,
+        "regression_indicated": false,
+        "improvement_indicated": false
+      },
+      "lookback_z_score": {
+        "z_threshold": 5.0,
+        "z_score": -200.0,
+        "regression_indicated": true,
+        "improvement_indicated": false
+      }
+    }
   },
   {
-    "baseline": "10.459 s",
-    "baseline_batch_id": "batch1",
-    "baseline_id": "sha1",
-    "baseline_run_id": 1,
-    "batch": "file-write",
-    "benchmark": "benchmark 3",
-    "change": "0.659%",
-    "contender": "10.528 s",
-    "contender_batch_id": "batch2",
-    "contender_id": "sha2",
-    "contender_run_id": 2,
-    "contender_z_improvement": false,
-    "less_is_better": true,
-    "contender_z_regression": false,
     "unit": "s",
-    "language": "Python",
-    "contender_z_score": -200.00
+    "less_is_better": true,
+    "baseline": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 3",
+      "language": "Python",
+      "value": 10.459,
+      "error": false,
+      "benchmark_result_id": "sha1",
+      "batch_id": "batch1",
+      "run_id": 1,
+      "tags": []
+    },
+    "contender": {
+      "benchmark_name": "file-write",
+      "case_permutation": "benchmark 3",
+      "language": "Python",
+      "value": 10.528,
+      "error": false,
+      "benchmark_result_id": "sha2",
+      "batch_id": "batch2",
+      "run_id": 2,
+      "tags": []
+    },
+    "analysis": {
+      "pairwise": {
+        "percent_change": 0.659,
+        "percent_threshold": 5.0,
+        "regression_indicated": false,
+        "improvement_indicated": false
+      },
+      "lookback_z_score": {
+        "z_threshold": 5.0,
+        "z_score": -200.0,
+        "regression_indicated": false,
+        "improvement_indicated": false
+      }
+    }
   }
 ]


### PR DESCRIPTION
Addresses https://github.com/conbench/conbench/issues/1280 by updating keys for subsetting results from the `/api/compare` endpoints, whose schema changed.