### PR TITLE
conbench http client: 180s read timeout, retry more often

### DIFF
--- a/integrations/__init__.py
+++ b/integrations/__init__.py
@@ -4,10 +4,17 @@ from requests.packages.urllib3.util.retry import Retry
 from config import Config
 from logger import log
 
-DEFAULT_TIMEOUT = 30
+# Note(JP): some requests are known to be responded to within O(1 min).
+# Set a large read timeout, but keep connect timeout smaller.
+# Also see
+# https://github.com/conbench/conbench/issues/801
+# https://github.com/conbench/conbench/issues/1283
+DEFAULT_TIMEOUT = (10, 180)
 
 retry_strategy = Retry(
-    total=5,
+    # keep retrying a little longer to survive smaller outages.
+    # Also see https://github.com/conbench/conbench/issues/800.
+    total=20,
     status_forcelist=[502, 503, 504],
     allowed_methods=frozenset(["GET", "POST"]),
     backoff_factor=4,  # will retry in 2, 4, 8, 16, 32 seconds


### PR DESCRIPTION
In view of https://github.com/conbench/conbench/issues/1283 we found that the previously chosen timeout constant was a little conservatively low (Arrow Conbench is known to take long to respond to some requests).