### PR TITLE
benchadapt: bump to current head of main (RetryingHTTPClient)

### DIFF
--- a/adapters/requirements.txt
+++ b/adapters/requirements.txt
@@ -1,1 +1,1 @@
-benchadapt
+benchadapt@git+https://github.com/conbench/conbench.git@81a0272cc2#subdirectory=benchadapt/python


### PR DESCRIPTION
For https://github.com/voltrondata-labs/arrow-benchmarks-ci/issues/121.

Not so sure if https://github.com/voltrondata-labs/arrow-benchmarks-ci/blob/ad5e8b2ce28a35e6786e02491d7a523787f51256/adapters/mock-adapter.py#L5 will be a problem. Let's see!