### PR TITLE
bump benchclients to current head of main

### DIFF
--- a/adapters/requirements.txt
+++ b/adapters/requirements.txt
@@ -1,1 +1,2 @@
 benchadapt@git+https://github.com/conbench/conbench.git@81a0272cc2#subdirectory=benchadapt/python
+benchclients@git+https://github.com/conbench/conbench.git@81a0272cc2#subdirectory=benchclients/python


### PR DESCRIPTION
For #121. #122 was not enough.

This is brute force. The dependency tree complex like a beautifully decorated christmas stree.

Goal is to replace Conbenclient here: https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-ec2-t3-xlarge-us-east-2/builds/2956#0188714a-7ade-4969-814d-4e87ed2103f4/33-4870
```
[230531-11:09:02.748] [1152258] [buildkite.benchmark.run] INFO: [230531-11:04:33.235] [1152349] [benchadapt.adapters] INFO: Initializing adapter
[230531-11:05:04.282] [1152349] [root] INFO: Time to POST https://conbench.ursa.dev/api/login/: 0.19455 s
[230531-11:05:04.341] [1152349] [root] INFO: Time to POST https://conbench.ursa.dev/api/benchmarks/: 0.05900 s
[230531-11:08:34.475] [1152349] [root] INFO: Time to POST https://conbench.ursa.dev/api/benchmarks/: 0.04551 s
[230531-11:09:01.846] [1152349] [root] INFO: Time to POST https://conbench.ursa.dev/api/benchmarks/: 0.03595 s
```
(these log msgs suggest old Conbenchclient)
