### PR TITLE
fix a small typo that caused #120

### DIFF
--- a/buildkite/schedule_and_publish/publish_benchmark_results_on_slack.py
+++ b/buildkite/schedule_and_publish/publish_benchmark_results_on_slack.py
@@ -21,6 +21,11 @@ def publish_benchmark_results_on_slack():
                 notification.mark_finished()
                 messages.append(text)
         except Exception as e:
+            log.error(
+                "Caught the following exception when trying to publish a slack message "
+                "for notification ID '%s'. Continuing on.",
+                notification.id,
+            )
             log.exception(e)
 
     return messages

--- a/models/notification.py
+++ b/models/notification.py
@@ -56,7 +56,7 @@ class Notification(Base, BaseMixin):
         ):
             if not self.benchmarkable.machine_run(
                 machine
-            ) and not self.benchmarkable.baseline_machine_run(machine):
+            ) or not self.benchmarkable.baseline_machine_run(machine):
                 continue
 
             status = self.benchmarkable.machine_runs_status(machine)
@@ -94,7 +94,9 @@ class Notification(Base, BaseMixin):
     def generate_pull_comment_body_for_high_regression_alert(
         self, benchmark_langs_filter, benchmark_machine_ignorelist
     ):
-        runs = self.benchmarkable.runs_with_high_regressions(benchmark_langs_filter, benchmark_machine_ignorelist)
+        runs = self.benchmarkable.runs_with_high_regressions(
+            benchmark_langs_filter, benchmark_machine_ignorelist
+        )
         if not runs:
             return
 


### PR DESCRIPTION
Fixes #120. This PR fixes what I assume to be a small typo in `Notification.generate_comment_with_compare_runs_links()`.

Before this PR, we'd skip generating a comment sentence for a given machine name if there were no associated runs on that machine AND there were no associated baseline runs on that machine. But I think the intention was to skip generating a sentence if either there were no runs OR no baseline runs on that machine.

Testing locally, I think the build was getting caught up on the `pyarrow==7.0.0` release (so this has been happening for over a year!) because it did have a run but not a baseline run. This should fix that.

The test suite is too confusing to figure out in a short time, and once we switch to `benchalerts` (#98) this code will change, so I won't add tests right now. I'll just monitor the build upon merge to ensure this does what I think it will.