### PR TITLE
Don't run the s3 downloading tests on the m1 mac

### DIFF
--- a/config.py
+++ b/config.py
@@ -173,7 +173,6 @@ class Config:
             "default_filters": {
                 "arrow-commit": {
                     "langs": {
-                        "Python": {"names": ["dataset-read", "dataset-select"]},
                         "C++": {"names": ["cpp-micro"]},
                         "R": {"names": ["tpch"]},
                     }


### PR DESCRIPTION
I suspect most people aren't even looking at these, but given where this machine is, there is a high amount of variation due only to measuring the connection from the location to S3. Ideally, we would be better looking at the runs of these same benchmarks we already do on ec2.

cc @westonpace @mike-wendt 