### PR TITLE
temporary fix to help churn through notifications backlog

### DIFF
--- a/buildkite/schedule_and_publish/pipeline.yml
+++ b/buildkite/schedule_and_publish/pipeline.yml
@@ -1,10 +1,42 @@
 steps:
-  - label: "Build Arrow-BCI API Service Docker Image"
+  - label: "Pull Arrow-BCI API Service Docker Image"
     concurrency: 1
     concurrency_group: "arrow-bci-deploy"
     command:
-      - docker-compose -f envs/prod/docker-compose.yml down
-      - docker-compose -f envs/prod/docker-compose.yml build
+      - aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${DOCKER_REGISTRY}
+      - docker pull ${DOCKER_REGISTRY}/${FLASK_APP}:${BUILDKITE_COMMIT}
+
+  - wait
+
+  - label: "Get Commits"
+    concurrency: 1
+    concurrency_group: "arrow-bci-deploy"
+    command:
+      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.get_commits import get_commits; get_commits()'
+
+  - wait
+
+  - label: "Get PyArrow Versions"
+    concurrency: 1
+    concurrency_group: "arrow-bci-deploy"
+    command:
+      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.get_pyarrow_versions import get_pyarrow_versions; get_pyarrow_versions()'
+
+  - wait
+
+  - label: "Create Benchmark Builds"
+    concurrency: 1
+    concurrency_group: "arrow-bci-deploy"
+    command:
+      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.create_benchmark_builds import create_benchmark_builds; create_benchmark_builds()'
+
+  - wait
+
+  - label: "Update Benchmark Builds Status"
+    concurrency: 1
+    concurrency_group: "arrow-bci-deploy"
+    command:
+      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.update_benchmark_builds_status import update_benchmark_builds_status; update_benchmark_builds_status()'
 
   - wait
 
@@ -13,3 +45,45 @@ steps:
     concurrency_group: "arrow-bci-deploy"
     command:
       - docker-compose -f envs/prod/docker-compose.yml run app python -m buildkite.schedule_and_publish.run_benchalerts
+
+  - wait
+
+  - label: "Publish Warnings on Slack"
+    concurrency: 1
+    concurrency_group: "arrow-bci-deploy"
+    command:
+      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.publish_warnings_on_slack import publish_offline_machine_warnings_on_slack; publish_offline_machine_warnings_on_slack()'
+      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.publish_warnings_on_slack import publish_buildkite_build_warnings_on_slack; publish_buildkite_build_warnings_on_slack()'
+
+  - block: "Reschedule Failed Builds"
+    prompt: "Select machines that need failed builds rescheduled"
+    fields:
+      - select: "Machines"
+        key: "machines"
+        required: true
+        multiple: true
+        options:
+          - label: "ursa-i9-9960x"
+            value: "ursa-i9-9960x"
+          - label: "ursa-thinkcentre-m75q"
+            value: "ursa-thinkcentre-m75q"
+          - label: "ec2-t3-xlarge-us-east-2"
+            value: "ec2-t3-xlarge-us-east-2"
+          - label: "test-mac-arm"
+            value: "test-mac-arm"
+          - label: "voltron-pavilion"
+            value: "voltron-pavilion"
+      - text: "Hours"
+        key: "hours"
+        required: true
+        default: "24"
+
+  - label: "Reschedule Failed Builds"
+    concurrency: 1
+    concurrency_group: "arrow-bci-deploy"
+    command: |
+      aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${DOCKER_REGISTRY}
+      docker pull ${DOCKER_REGISTRY}/${FLASK_APP}:${BUILDKITE_COMMIT}
+      export MACHINES_WITH_FAILED_BUILDS=$(buildkite-agent meta-data get machines)
+      export HOURS_WITH_FAILED_BUILDS=$(buildkite-agent meta-data get hours)
+      docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.reschedule_failed_builds import reschedule_failed_builds; reschedule_failed_builds()'

--- a/buildkite/schedule_and_publish/pipeline.yml
+++ b/buildkite/schedule_and_publish/pipeline.yml
@@ -1,42 +1,10 @@
 steps:
-  - label: "Pull Arrow-BCI API Service Docker Image"
+  - label: "Build Arrow-BCI API Service Docker Image"
     concurrency: 1
     concurrency_group: "arrow-bci-deploy"
     command:
-      - aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${DOCKER_REGISTRY}
-      - docker pull ${DOCKER_REGISTRY}/${FLASK_APP}:${BUILDKITE_COMMIT}
-
-  - wait
-
-  - label: "Get Commits"
-    concurrency: 1
-    concurrency_group: "arrow-bci-deploy"
-    command:
-      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.get_commits import get_commits; get_commits()'
-
-  - wait
-
-  - label: "Get PyArrow Versions"
-    concurrency: 1
-    concurrency_group: "arrow-bci-deploy"
-    command:
-      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.get_pyarrow_versions import get_pyarrow_versions; get_pyarrow_versions()'
-
-  - wait
-
-  - label: "Create Benchmark Builds"
-    concurrency: 1
-    concurrency_group: "arrow-bci-deploy"
-    command:
-      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.create_benchmark_builds import create_benchmark_builds; create_benchmark_builds()'
-
-  - wait
-
-  - label: "Update Benchmark Builds Status"
-    concurrency: 1
-    concurrency_group: "arrow-bci-deploy"
-    command:
-      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.update_benchmark_builds_status import update_benchmark_builds_status; update_benchmark_builds_status()'
+      - docker-compose -f envs/prod/docker-compose.yml down
+      - docker-compose -f envs/prod/docker-compose.yml build
 
   - wait
 
@@ -45,45 +13,3 @@ steps:
     concurrency_group: "arrow-bci-deploy"
     command:
       - docker-compose -f envs/prod/docker-compose.yml run app python -m buildkite.schedule_and_publish.run_benchalerts
-
-  - wait
-
-  - label: "Publish Warnings on Slack"
-    concurrency: 1
-    concurrency_group: "arrow-bci-deploy"
-    command:
-      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.publish_warnings_on_slack import publish_offline_machine_warnings_on_slack; publish_offline_machine_warnings_on_slack()'
-      - docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.publish_warnings_on_slack import publish_buildkite_build_warnings_on_slack; publish_buildkite_build_warnings_on_slack()'
-
-  - block: "Reschedule Failed Builds"
-    prompt: "Select machines that need failed builds rescheduled"
-    fields:
-      - select: "Machines"
-        key: "machines"
-        required: true
-        multiple: true
-        options:
-          - label: "ursa-i9-9960x"
-            value: "ursa-i9-9960x"
-          - label: "ursa-thinkcentre-m75q"
-            value: "ursa-thinkcentre-m75q"
-          - label: "ec2-t3-xlarge-us-east-2"
-            value: "ec2-t3-xlarge-us-east-2"
-          - label: "test-mac-arm"
-            value: "test-mac-arm"
-          - label: "voltron-pavilion"
-            value: "voltron-pavilion"
-      - text: "Hours"
-        key: "hours"
-        required: true
-        default: "24"
-
-  - label: "Reschedule Failed Builds"
-    concurrency: 1
-    concurrency_group: "arrow-bci-deploy"
-    command: |
-      aws ecr get-login-password --region us-east-2 | docker login --username AWS --password-stdin ${DOCKER_REGISTRY}
-      docker pull ${DOCKER_REGISTRY}/${FLASK_APP}:${BUILDKITE_COMMIT}
-      export MACHINES_WITH_FAILED_BUILDS=$(buildkite-agent meta-data get machines)
-      export HOURS_WITH_FAILED_BUILDS=$(buildkite-agent meta-data get hours)
-      docker-compose -f envs/prod/docker-compose.yml run app python -c 'from buildkite.schedule_and_publish.reschedule_failed_builds import reschedule_failed_builds; reschedule_failed_builds()'

--- a/buildkite/schedule_and_publish/run_benchalerts.py
+++ b/buildkite/schedule_and_publish/run_benchalerts.py
@@ -1,5 +1,7 @@
 import os
 
+from benchclients.http import RetryingHTTPClientDeadlineReached
+
 from integrations.slack import Slack
 from logger import log
 from models.benchalerts_run import BenchalertsRun
@@ -51,6 +53,10 @@ def run_benchalerts():
     for benchalerts_run in unfinished_runs:
         try:
             run_one_benchalerts_run(benchalerts_run)
+        except RetryingHTTPClientDeadlineReached as e:
+            log.info(f"Marking {benchalerts_run.id} as finished due to timeout")
+            benchalerts_run.mark_finished(None, None)
+            benchalerts_errors.append(e)
         except Exception as e:
             log.exception(f"Error running benchalerts: {repr(e)}")
             benchalerts_errors.append(e)

--- a/models/benchalerts_run.py
+++ b/models/benchalerts_run.py
@@ -90,7 +90,7 @@ class BenchalertsRun(Base, BaseMixin):
             conbench_client = MockBenchclientsConbenchClient(adapter=adapter)
             github_client = MockBenchalertsGitHubClient(adapter=adapter)
         else:
-            conbench_client = None
+            conbench_client = ConbenchClient(default_retry_for_seconds=5 * 60)
             github_client = None
 
         run_ids = [


### PR DESCRIPTION
This implements option (3) of https://github.com/voltrondata-labs/arrow-benchmarks-ci/issues/148#issuecomment-1644208839.

I will pause the normal `schedule_and_publish` pipeline schedule, and kick off a Buildkite build of this pipeline on this branch with no global timeout. It should try to go through each item in the queue, one at a time. If it can't get a compare result after 5 minutes (probably 4 tries of 60 seconds each) it will mark that notification as "finished" without posting a message, and say so in the logs.

Hopefully there's only a few problematic notification runs, and the rest of them work.