### PR TITLE
Revert "temporary fix to help churn through notifications backlog"

### DIFF
--- a/buildkite/schedule_and_publish/run_benchalerts.py
+++ b/buildkite/schedule_and_publish/run_benchalerts.py
@@ -1,7 +1,5 @@
 import os
 
-from benchclients.http import RetryingHTTPClientDeadlineReached
-
 from integrations.slack import Slack
 from logger import log
 from models.benchalerts_run import BenchalertsRun
@@ -53,10 +51,6 @@ def run_benchalerts():
     for benchalerts_run in unfinished_runs:
         try:
             run_one_benchalerts_run(benchalerts_run)
-        except RetryingHTTPClientDeadlineReached as e:
-            log.info(f"Marking {benchalerts_run.id} as finished due to timeout")
-            benchalerts_run.mark_finished(None, None)
-            benchalerts_errors.append(e)
         except Exception as e:
             log.exception(f"Error running benchalerts: {repr(e)}")
             benchalerts_errors.append(e)

--- a/models/benchalerts_run.py
+++ b/models/benchalerts_run.py
@@ -90,7 +90,7 @@ class BenchalertsRun(Base, BaseMixin):
             conbench_client = MockBenchclientsConbenchClient(adapter=adapter)
             github_client = MockBenchalertsGitHubClient(adapter=adapter)
         else:
-            conbench_client = ConbenchClient(default_retry_for_seconds=5 * 60)
+            conbench_client = None
             github_client = None
 
         run_ids = [


### PR DESCRIPTION
Reverts voltrondata-labs/arrow-benchmarks-ci#150. Working on #148.