### PR TITLE
Skip commits on i9 matching certain strings

### DIFF
--- a/config.py
+++ b/config.py
@@ -98,7 +98,15 @@ class Config:
                             ]
                         },
                         "JavaScript": {"names": ["js-micro"]},
-                    }
+                    },
+                    "commit_message_skip_strings": [
+                        "[C#]",
+                        "[Doc]",
+                        "[Docs]",
+                        "[Go]",
+                        "[Java]",
+                        "[MATLAB]",
+                    ],
                 },
                 "pyarrow-apache-wheel": {
                     "langs": {

--- a/config.py
+++ b/config.py
@@ -68,7 +68,8 @@ class Config:
 
     MACHINES = {
         "ursa-i9-9960x": {
-            "info": "Supported benchmark langs: Python, R, JavaScript",
+            "info": "Supported benchmark langs: Python, R, JavaScript. Skips certain "
+            "commit messages if they contain certain strings.",
             "default_filters": {
                 "arrow-commit": {
                     "langs": {
@@ -101,6 +102,7 @@ class Config:
                     },
                     "commit_message_skip_strings": [
                         "[C#]",
+                        "[CI]",
                         "[Doc]",
                         "[Docs]",
                         "[Go]",

--- a/models/benchmarkable.py
+++ b/models/benchmarkable.py
@@ -1,5 +1,6 @@
 import functools
 import traceback
+from typing import Optional
 
 import sqlalchemy as s
 from sqlalchemy.dialects import postgresql
@@ -62,7 +63,7 @@ class Benchmarkable(Base, BaseMixin):
                 return self.data["committer"]["html_url"]
 
     @property
-    def displayable_message(self):
+    def displayable_message(self) -> Optional[str]:
         if self.is_commit():
             # Remove % since they cause JSON parsing issues when passed to buildkite.
             # TODO: are there other characters we should also check? And is it possible
@@ -125,7 +126,10 @@ class Benchmarkable(Base, BaseMixin):
     def add_runs(self, override_filters, reason):
         for machine in Machine.all():
             filters, skip_reason = machine.run_filters_and_skip_reason(
-                self.type, override_filters
+                benchmarkable_type=self.type,
+                benchmarkable_reason=reason,
+                benchmarkable_commit_msg=self.displayable_message,
+                override_filters=override_filters,
             )
             self.runs.append(
                 Run(

--- a/models/machine.py
+++ b/models/machine.py
@@ -1,7 +1,7 @@
 import socket
 from copy import deepcopy
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Tuple
 
 import sqlalchemy as s
 from authlib.jose import jwt
@@ -55,7 +55,17 @@ class Machine(Base, BaseMixin):
         benchmarkable_reason: str,
         benchmarkable_commit_msg: Optional[str],
         override_filters: Optional[dict],
-    ):
+    ) -> Tuple[dict, Optional[str]]:
+        """Decide which benchmarks to run on this machine.
+
+        Return a tuple of augmented filters (default filters + override filters) and an
+        optional reason to skip benchmarks altogether. If the skip_reason is not None,
+        the scheduler should not start a benchmark run on this machine for this
+        benchmarkable.
+
+        If the skip_reason is None, the returned augmented run_filters should be passed
+        to the Buildkite job so that they can be applied to benchmarks during the job.
+        """
         if benchmarkable_type not in self.default_filters:
             return (
                 {},
@@ -67,11 +77,12 @@ class Machine(Base, BaseMixin):
         if (
             "commit_message_skip_strings" in machine_run_filters
             # never skip PRs or wheels with otherwise-skippable commit messages
+            # (possible reasons: arrow-commit, other-project-commit, pull-request, pyarrow-apache-wheel)
             and benchmarkable_reason.endswith("-commit")
             and benchmarkable_commit_msg
         ):
             for skip_string in machine_run_filters["commit_message_skip_strings"]:
-                if skip_string in benchmarkable_commit_msg:
+                if skip_string.upper() in benchmarkable_commit_msg.upper():
                     return (
                         machine_run_filters,
                         f"The following commit message is skipped on {self.name} due "

--- a/models/machine.py
+++ b/models/machine.py
@@ -1,6 +1,7 @@
 import socket
 from copy import deepcopy
 from datetime import datetime
+from typing import Optional
 
 import sqlalchemy as s
 from authlib.jose import jwt
@@ -48,7 +49,13 @@ class Machine(Base, BaseMixin):
     def delete_benchmark_pipeline(self):
         buildkite.delete_pipeline(self.buildkite_pipeline_name)
 
-    def run_filters_and_skip_reason(self, benchmarkable_type, override_filters=None):
+    def run_filters_and_skip_reason(
+        self,
+        benchmarkable_type: str,
+        benchmarkable_reason: str,
+        benchmarkable_commit_msg: Optional[str],
+        override_filters: Optional[dict],
+    ):
         if benchmarkable_type not in self.default_filters:
             return (
                 {},
@@ -56,6 +63,20 @@ class Machine(Base, BaseMixin):
             )
 
         machine_run_filters = deepcopy(self.default_filters[benchmarkable_type])
+
+        if (
+            "commit_message_skip_strings" in machine_run_filters
+            # never skip PRs or wheels with otherwise-skippable commit messages
+            and benchmarkable_reason.endswith("-commit")
+            and benchmarkable_commit_msg
+        ):
+            for skip_string in machine_run_filters["commit_message_skip_strings"]:
+                if skip_string in benchmarkable_commit_msg:
+                    return (
+                        machine_run_filters,
+                        f"The following commit message is skipped on {self.name} due "
+                        f"to containing '{skip_string}': {benchmarkable_commit_msg}",
+                    )
 
         if not override_filters:
             return machine_run_filters, None

--- a/tests/api/test_events.py
+++ b/tests/api/test_events.py
@@ -15,6 +15,7 @@ from tests.helpers import (
     filter_with_java_script_only_benchmarks,
     filter_with_python_only_benchmarks,
     filter_with_r_only_benchmarks,
+    skip_strings,
     machine_configs,
     make_github_webhook_event_for_comment,
     mock_offline_machine,
@@ -26,7 +27,7 @@ from tests.helpers import (
 
 pull_comments_with_expected_machine_run_filters_and_skip_reason = {
     "@ursabot please benchmark lang=Python": {
-        "ursa-i9-9960x": (filter_with_python_only_benchmarks, None),
+        "ursa-i9-9960x": ({**filter_with_python_only_benchmarks, **skip_strings}, None),
         "ursa-thinkcentre-m75q": (
             {"lang": "Python"},
             "Only ['C++', 'Java'] langs are supported on ursa-thinkcentre-m75q",
@@ -65,7 +66,7 @@ pull_comments_with_expected_machine_run_filters_and_skip_reason = {
         ),
     },
     "@ursabot please benchmark lang=Python   ": {
-        "ursa-i9-9960x": (filter_with_python_only_benchmarks, None),
+        "ursa-i9-9960x": ({**filter_with_python_only_benchmarks, **skip_strings}, None),
         "ursa-thinkcentre-m75q": (
             {"lang": "Python"},
             "Only ['C++', 'Java'] langs are supported on ursa-thinkcentre-m75q",
@@ -76,7 +77,10 @@ pull_comments_with_expected_machine_run_filters_and_skip_reason = {
         ),
     },
     "@ursabot please benchmark lang=JavaScript   ": {
-        "ursa-i9-9960x": (filter_with_java_script_only_benchmarks, None),
+        "ursa-i9-9960x": (
+            {**filter_with_java_script_only_benchmarks, **skip_strings},
+            None,
+        ),
         "ursa-thinkcentre-m75q": (
             {"lang": "JavaScript"},
             "Only ['C++', 'Java'] langs are supported on ursa-thinkcentre-m75q",
@@ -103,7 +107,7 @@ pull_comments_with_expected_machine_run_filters_and_skip_reason = {
         "new-machine": (filter_with_cpp_only_benchmarks, None),
     },
     "@ursabot please benchmark lang=R": {
-        "ursa-i9-9960x": (filter_with_r_only_benchmarks, None),
+        "ursa-i9-9960x": ({**filter_with_r_only_benchmarks, **skip_strings}, None),
         "ursa-thinkcentre-m75q": (
             {"lang": "R"},
             "Only ['C++', 'Java'] langs are supported on ursa-thinkcentre-m75q",
@@ -114,7 +118,10 @@ pull_comments_with_expected_machine_run_filters_and_skip_reason = {
         ),
     },
     "@ursabot please benchmark name=file-write": {
-        "ursa-i9-9960x": (filter_with_file_write_only_benchmarks, None),
+        "ursa-i9-9960x": (
+            {**filter_with_file_write_only_benchmarks, **skip_strings},
+            None,
+        ),
         "ursa-thinkcentre-m75q": (
             {"name": "file-write"},
             "Only ['lang', 'command'] filters are supported on ursa-thinkcentre-m75q",
@@ -125,7 +132,10 @@ pull_comments_with_expected_machine_run_filters_and_skip_reason = {
         ),
     },
     "@ursabot please benchmark name=file-write lang=Python": {
-        "ursa-i9-9960x": (filter_with_file_write_python_only_benchmarks, None),
+        "ursa-i9-9960x": (
+            {**filter_with_file_write_python_only_benchmarks, **skip_strings},
+            None,
+        ),
         "ursa-thinkcentre-m75q": (
             {"lang": "Python", "name": "file-write"},
             "Only ['C++', 'Java'] langs are supported on ursa-thinkcentre-m75q",
@@ -136,7 +146,10 @@ pull_comments_with_expected_machine_run_filters_and_skip_reason = {
         ),
     },
     "@ursabot please benchmark    name=file-write  lang=Python ": {
-        "ursa-i9-9960x": (filter_with_file_write_python_only_benchmarks, None),
+        "ursa-i9-9960x": (
+            {**filter_with_file_write_python_only_benchmarks, **skip_strings},
+            None,
+        ),
         "ursa-thinkcentre-m75q": (
             {"lang": "Python", "name": "file-write"},
             "Only ['C++', 'Java'] langs are supported on ursa-thinkcentre-m75q",
@@ -147,7 +160,7 @@ pull_comments_with_expected_machine_run_filters_and_skip_reason = {
         ),
     },
     "@ursabot please benchmark name=file-*": {
-        "ursa-i9-9960x": (filter_with_file_only_benchmarks, None),
+        "ursa-i9-9960x": ({**filter_with_file_only_benchmarks, **skip_strings}, None),
         "ursa-thinkcentre-m75q": (
             {"name": "file-*"},
             "Only ['lang', 'command'] filters are supported on ursa-thinkcentre-m75q",

--- a/tests/buildkite/schedule_and_publish/test_get_commits.py
+++ b/tests/buildkite/schedule_and_publish/test_get_commits.py
@@ -28,8 +28,18 @@ def verify_benchmarkable_runs(commit_dict):
         assert run
         assert run.filters == machine.default_filters["arrow-commit"]
         assert run.reason == "arrow-commit"
-        assert run.status == "created"
-        assert not run.finished_at
+
+        if machine.name == "ursa-i9-9960x" and (
+            "[Go]" in commit_dict["commit"]["message"]
+            or "[Doc]" in commit_dict["commit"]["message"]
+        ):
+            assert run.status == "skipped"
+            assert run.skip_reason
+            assert run.finished_at
+        else:
+            assert run.status == "created"
+            assert not run.skip_reason
+            assert not run.finished_at
 
 
 def verify_benchmarkable_benchalerts_runs(

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -13,6 +13,16 @@ outbound_requests = []
 test_pull_number = 1234
 test_benchmarkable_id = "sha2"
 test_baseline_benchmarkable_id = "sha1"
+skip_strings = {
+    "commit_message_skip_strings": [
+        "[C#]",
+        "[Doc]",
+        "[Docs]",
+        "[Go]",
+        "[Java]",
+        "[MATLAB]",
+    ]
+}
 machine_configs = {
     "ursa-i9-9960x": {
         "info": "Supported benchmark langs: Python, R, JavaScript",
@@ -42,7 +52,8 @@ machine_configs = {
                         ]
                     },
                     "JavaScript": {"names": ["js-micro"]},
-                }
+                },
+                **skip_strings,
             },
             "pyarrow-apache-wheel": {
                 "langs": {

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -16,6 +16,7 @@ test_baseline_benchmarkable_id = "sha1"
 skip_strings = {
     "commit_message_skip_strings": [
         "[C#]",
+        "[CI]",
         "[Doc]",
         "[Docs]",
         "[Go]",


### PR DESCRIPTION
The backlog of Arrow commits to benchmark on the `ursa-i9-9960x` machine is getting long. For now, I propose we stop running benchmarks on commits with commit messages that contain certain strings.

After merging this PR, I'll make a small database migration to apply this change to the commits that are already in the backlog. As this PR stands today, that would include skipping the following commits:

<details>
<summary>(skipped commits)</summary>

- MINOR: [Go] Add gRPC status details to sample Flight SQL server (#37026)
- MINOR: [C#] Bump Microsoft.NET.Test.Sdk from 15.8.0 to 17.7.0 in /csharp (#37038)
- MINOR: [C#] Bump xunit from 2.4.0 to 2.5.0 in /csharp (#37036)
- GH-37049: [MATLAB] Update feather `Reader` and `Writer` objects to work directly with `arrow.tabular.RecordBatch`s instead of MATLAB `table`s (#37052)
- MINOR: [C#] Bump Microsoft.SourceLink.GitHub from 1.0.0 to 1.1.1 in /csharp (#37037)
- MINOR: [C#] Bump coverlet.collector from 1.2.0 to 6.0.0 in /csharp (#36596)
- MINOR: [C#] Bump BenchmarkDotNet.Diagnostics.Windows from 0.13.5 to 0.13.7 in /csharp (#37035)
- GH-37045: [MATLAB] Implement featherwrite in terms of arrow.internal.io.feather.Writer (#37047)
- MINOR: [C#] Bump xunit.runner.visualstudio from 2.4.0 to 2.5.0 in /csharp (#36728)
- GH-37041: [MATLAB] Implement Feather V1 Reader using new MATLAB Interface APIs (#37044)
- GH-37042: [MATLAB] Implement Feather V1 Writer using new MATLAB Interface APIs (#37043)
- GH-36936: [Go] Make it possible to register custom functions. (#36959)
- MINOR: [Docs] add note about how comment bot assigns users (#36362)
- MINOR: [Docs] Fix a typo in env_vars.rst (#37030)
- GH-36984: [MATLAB] Create `arrow.recordbatch` convenience constructor function (#37025)
- GH-37012:  [MATLAB] Remove the private property `ArrowArrays` from `arrow.tabular.RecordBatch` (#37015)
- GH-36961: [MATLAB] Add `arrow.tabular.Schema` class and associated `arrow.schema` construction function (#37013)
- GH-36953: [MATLAB] Add gateway `arrow.array` function to create Arrow Arrays from MATLAB data (#36978)
- MINOR: [Doc][Release] Update wrong reference from JIRA to GitHub issues (#36989)
- GH-36069: [Java] Ensure S3 is finalized on shutdown (#36934)
- MINOR: [C#] Bump Grpc.Net.Client from 2.52.0 to 2.55.0 in /csharp (#36729)
- MINOR: [C#] Bump Grpc.Tools from 2.42.0 to 2.56.2 in /csharp (#36727)
- GH-36981: [Go] Fix ipc reader leak (#36982)
- GH-36935: [Go] Fix Timestamp to Time dates (#36964)
- GH-36927: [Java][Docs] Enable Gandiva build as part of Java maven commands (#36929)
- GH-35409: [Python][Docs] Clarify S3FileSystem Credentials chain for EC2 (#35312)
- GH-36941: [CI][Docs] Use system Protobuf (#36943)
- GH-36928: [Java] Make it run well with the netty newest version 4.1.96 (#36926)
</details>

But NOT skipping these commits, and still running benchmarks for them:

<details>
<summary>(run commits)</summary>

- GH-36892: [C++] Fix performance regressions in `FieldPath::Get` (#37032)
- MINOR: [JS] Bump semver from 5.7.1 to 5.7.2 in /js (#36603)
- MINOR: [C++] Fix a lint failure (#37048)
- MINOR: [JS] Bump word-wrap from 1.2.3 to 1.2.4 in /js (#36761)
- GH-36886: [C++] Configure `azurite` in preparation for testing Azure C++ filesystem (#36988)
- GH-36642: [Python][CI] Configure warnings as errors during pytest (#37018)
- MINOR: [C++] Fix a typo in Acero agg description (#37031)
- MINOR: [C++] async_until typo fix (#37029)
- GH-36752: [Python] Remove AWS SDK bundling when building wheels (#36925)
- GH-36856: [C++] Remove needless braces from BasicDecimal256FromLE() arguments (#36987)
- GH-36189: [C++][Parquet] StreamReader::SkipRows() skips to incorrect place in multi-row-group files (#36191)
- GH-36970: [C++][Parquet] Minor style fix for parquet metadata (#36971)
- GH-36975: [C++][FlightRPC] Skip unknown fields, don't crash (#36979)
- MINOR: [C++] Acero tiny typo fix (#36938)
- GH-36199: [Python][CI][Spark] Update spark versions used on our nightly tests (#36347)
- GH-36973: [CI][Python] Archery linter integrated with flake8==6.1.0 (#36976)
- GH-36692: [CI][Packaging] Pin gemfury to 0.12.0 due to issue with faraday dependency (#36693)
- GH-36947: [CI] Move free up disk space to the Jinja macros to be able to reuse it on docs job (#36948)
- GH-36323: [Python] Fix Timestamp scalar repr error on values outside datetime range (#36942)
- GH-36952: [C++][FlightRPC][Python] Add methods to send headers (#36956)
- GH-36944: [C++] Unify OpenSSL detection for building GCS (#36945)
- GH-36685: [R][C++] Fix illegal opcode failure with Homebrew (#36705)
- GH-36837: [CI][RPM] Use multi-cores to install gems (#36838)
- GH-36883: [R] Remove version number which triggers CRAN warning (#36884)
</details>

And the same matching behavior would apply to all new commits moving forward.