### PR TITLE
Make debugging benchalerts easier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM python:3.8
 
 COPY requirements-test.txt /tmp/
-RUN pip install -r /tmp/requirements-test.txt
-
 COPY requirements.txt /tmp/
-RUN pip install -r /tmp/requirements.txt
+RUN pip install -r /tmp/requirements-test.txt -r /tmp/requirements.txt
 
 WORKDIR /app
 ADD . /app

--- a/buildkite/schedule_and_publish/run_benchalerts.py
+++ b/buildkite/schedule_and_publish/run_benchalerts.py
@@ -16,8 +16,8 @@ def run_one_benchalerts_run(benchalerts_run: BenchalertsRun) -> None:
 
     benchalerts_run.run_benchalerts()
     log.info(
-        f"Finished benchalerts run. Status: {benchalerts_run.status}, link: "
-        f"{benchalerts_run.check_link}"
+        f"Finished benchalerts run. Status: {benchalerts_run.status}, check link: "
+        f"{benchalerts_run.check_link}, comment link: {benchalerts_run.pr_comment_link}"
     )
 
     # TODO: move this Slack step into the BenchalertsRun.run_benchalerts() pipeline
@@ -25,14 +25,14 @@ def run_one_benchalerts_run(benchalerts_run: BenchalertsRun) -> None:
         msg = (
             f"The `benchalerts` run for {benchalerts_run.reason} "
             f"`{benchalerts_run.benchmarkable_id[:7]}` had benchmark failures. Please "
-            f"see the report for more details: {benchalerts_run.check_link}"
+            f"see the report for more details: {benchalerts_run.pr_comment_link}"
         )
     elif benchalerts_run.status == "failure":
         msg = (
             f"The `benchalerts` run for {benchalerts_run.reason} "
             f"`{benchalerts_run.benchmarkable_id[:7]}` had benchmarks indicating a "
             "performance regression. Please see the report for more details: "
-            f"{benchalerts_run.check_link}"
+            f"{benchalerts_run.pr_comment_link}"
         )
     else:
         return

--- a/migrations/versions/c30e58775d47_pr_comment_link.py
+++ b/migrations/versions/c30e58775d47_pr_comment_link.py
@@ -1,0 +1,26 @@
+"""pr_comment_link
+
+Revision ID: c30e58775d47
+Revises: fd3c612364cf
+Create Date: 2023-10-02 12:46:03.070179
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c30e58775d47"
+down_revision = "fd3c612364cf"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "benchalerts_run", sa.Column("pr_comment_link", sa.String(), nullable=True)
+    )
+
+
+def downgrade():
+    op.drop_column("benchalerts_run", "pr_comment_link")

--- a/models/run.py
+++ b/models/run.py
@@ -53,7 +53,8 @@ class Run(Base, BaseMixin):
 
     @property
     def buildkite_build_web_url(self):
-        return self.buildkite_data.get("web_url")
+        if self.buildkite_data:
+            return self.buildkite_data.get("web_url")
 
     def buildkite_build_web_url_with_status(self, format):
         if format == "slack_message":

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ psutil
 psycopg2-binary
 requests
 SQLAlchemy>=1.4.0b1
+werkzeug==2.0.3

--- a/tests/mocked_integrations/github/post_issues_comments.json
+++ b/tests/mocked_integrations/github/post_issues_comments.json
@@ -1,4 +1,31 @@
 {
-  "url": "http://mocked-integrations:9999/github/repos/apache/arrow/issues/comments/1234",
-  "body": "test"
+    "id": 1,
+    "node_id": "MDEyOklzc3VlQ29tbWVudDE=",
+    "url": "https://api.github.com/repos/octocat/Hello-World/issues/comments/1",
+    "html_url": "https://github.com/octocat/Hello-World/issues/1347#issuecomment-1",
+    "body": "Me too",
+    "user": {
+        "login": "octocat",
+        "id": 1,
+        "node_id": "MDQ6VXNlcjE=",
+        "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/octocat",
+        "html_url": "https://github.com/octocat",
+        "followers_url": "https://api.github.com/users/octocat/followers",
+        "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+        "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+        "organizations_url": "https://api.github.com/users/octocat/orgs",
+        "repos_url": "https://api.github.com/users/octocat/repos",
+        "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/octocat/received_events",
+        "type": "User",
+        "site_admin": false
+    },
+    "created_at": "2011-04-14T16:00:49Z",
+    "updated_at": "2011-04-14T16:00:49Z",
+    "issue_url": "https://api.github.com/repos/octocat/Hello-World/issues/1347",
+    "author_association": "COLLABORATOR"
 }


### PR DESCRIPTION
This PR adds some small improvements to make it easier to debug what happened when benchmarks had failures or regressions.

1. The internal Slack message now points to the PR comment instead of the check run report. (This PR link is now stored in the DB too.)
2. The check run report now links to public Buildkite build logs.
3. The PR comment now reports the _number_ of unstable failures+regressions instead of just saying that they exist.
4. Also fixed a small bug where PR-requested benchmarks returned the wrong check status in some cases.