### PR TITLE
update machine config

### DIFF
--- a/config.py
+++ b/config.py
@@ -98,7 +98,8 @@ class Config:
                                 "tpch",
                             ]
                         },
-                        "JavaScript": {"names": ["js-micro"]},
+                        # Deactivating until https://github.com/apache/arrow/pull/37668 is merged
+                        # "JavaScript": {"names": ["js-micro"]},
                     },
                     "commit_message_skip_strings": [
                         "[C#]",
@@ -135,21 +136,21 @@ class Config:
             "publish_benchmark_results": True,
             "max_builds": 1,
         },
-        "ursa-thinkcentre-m75q": {
-            "info": "Supported benchmark langs: C++, Java",
-            "default_filters": {
-                "arrow-commit": {
-                    "langs": {
-                        "C++": {"names": ["cpp-micro"]},
-                        "Java": {"names": ["java-micro"]},
-                    }
-                }
-            },
-            "supported_filters": ["lang", "command"],
-            "offline_warning_enabled": True,
-            "publish_benchmark_results": True,
-            "max_builds": 1,
-        },
+        # "ursa-thinkcentre-m75q": {
+        #     "info": "Supported benchmark langs: C++, Java",
+        #     "default_filters": {
+        #         "arrow-commit": {
+        #             "langs": {
+        #                 "C++": {"names": ["cpp-micro"]},
+        #                 "Java": {"names": ["java-micro"]},
+        #             }
+        #         }
+        #     },
+        #     "supported_filters": ["lang", "command"],
+        #     "offline_warning_enabled": True,
+        #     "publish_benchmark_results": True,
+        #     "max_builds": 1,
+        # },
         "ec2-t3-xlarge-us-east-2": {
             "info": "Supported benchmark langs: Python, R. Runs only benchmarks with cloud = True",
             "default_filters": {

--- a/config.py
+++ b/config.py
@@ -136,21 +136,21 @@ class Config:
             "publish_benchmark_results": True,
             "max_builds": 1,
         },
-        # "ursa-thinkcentre-m75q": {
-        #     "info": "Supported benchmark langs: C++, Java",
-        #     "default_filters": {
-        #         "arrow-commit": {
-        #             "langs": {
-        #                 "C++": {"names": ["cpp-micro"]},
-        #                 "Java": {"names": ["java-micro"]},
-        #             }
-        #         }
-        #     },
-        #     "supported_filters": ["lang", "command"],
-        #     "offline_warning_enabled": True,
-        #     "publish_benchmark_results": True,
-        #     "max_builds": 1,
-        # },
+        "ursa-thinkcentre-m75q": {
+            "info": "Supported benchmark langs: C++, Java",
+            "default_filters": {
+                # "arrow-commit": {
+                #     "langs": {
+                #         "C++": {"names": ["cpp-micro"]},
+                #         "Java": {"names": ["java-micro"]},
+                #     }
+                # }
+            },
+            "supported_filters": ["lang", "command"],
+            "offline_warning_enabled": False,
+            "publish_benchmark_results": True,
+            "max_builds": 1,
+        },
         "ec2-t3-xlarge-us-east-2": {
             "info": "Supported benchmark langs: Python, R. Runs only benchmarks with cloud = True",
             "default_filters": {


### PR DESCRIPTION
This PR
- deactivates JS benchmarks until https://github.com/apache/arrow/pull/37668 is merged
- deactivates `ursa-thinkcentre-m75q` benchmarks until that machine is back online