### PR TITLE
Use libmamba solver

### DIFF
--- a/buildkite/benchmark-test/pipeline.yml
+++ b/buildkite/benchmark-test/pipeline.yml
@@ -9,16 +9,18 @@ steps:
         options:
           - label: "ec2-t3-xlarge-us-east-2 (Fastest build but only has Python benchmarks)"
             value: "ec2-t3-xlarge-us-east-2"
+          - label: "ec2-m5-4xlarge-us-east-2"
+            value: "ec2-m5-4xlarge-us-east-2"
           - label: "arm64-m6g-linux-compute (Preferable for testing builds with C++, Python, R benchmarks)"
             value: "arm64-m6g-linux-compute"
+          - label: "arm64-t4g-linux-compute"
+            value: "arm64-t4g-linux-compute"
           - label: "ursa-i9-9960x (Please avoid using this machine for running test builds)"
             value: "ursa-i9-9960x"
           - label: "ursa-thinkcentre-m75q (Please avoid using this machine for running test builds)"
             value: "ursa-thinkcentre-m75q"
           - label: "test-mac-arm (Please avoid using this machine for running test builds)"
             value: "test-mac-arm"
-          - label: "voltron-pavilion (Please avoid using this machine for running test builds)"
-            value: "voltron-pavilion"
 
   - label: "Test Benchmark Builds"
     command: |

--- a/buildkite/benchmark-test/run_test_builds.py
+++ b/buildkite/benchmark-test/run_test_builds.py
@@ -18,7 +18,11 @@ def run_test_builds():
             "BENCHMARKABLE": "HEAD",
             "BENCHMARKABLE_TYPE": benchmarkable_type,
             "FILTERS": json.dumps(
-                Config.MACHINES[machine]["default_filters"][benchmarkable_type]
+                {
+                    "langs": {
+                        "Python": {"names": ["dataframe-to-table"]},
+                    }
+                }
             ),
             "MACHINE": machine,
             "RUN_ID": generate_uuid(),

--- a/buildkite/benchmark-test/run_test_builds.py
+++ b/buildkite/benchmark-test/run_test_builds.py
@@ -18,11 +18,7 @@ def run_test_builds():
             "BENCHMARKABLE": "HEAD",
             "BENCHMARKABLE_TYPE": benchmarkable_type,
             "FILTERS": json.dumps(
-                {
-                    "langs": {
-                        "Python": {"names": ["dataframe-to-table"]},
-                    }
-                }
+                Config.MACHINES[machine]["default_filters"][benchmarkable_type]
             ),
             "MACHINE": machine,
             "RUN_ID": generate_uuid(),

--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -119,7 +119,8 @@ create_conda_env_and_run_benchmarks() {
       export REPO=https://github.com/apache/arrow.git
       export REPO_DIR=arrow
       clone_repo
-      create_conda_env_for_arrow_commit
+      # retry this sometimes-flaky step on ursa-i9
+      create_conda_env_for_arrow_commit || create_conda_env_for_arrow_commit
       test_pyarrow_is_built
       ;;
     "pyarrow-apache-wheel")

--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -7,9 +7,11 @@ init_conda() {
 create_conda_env_for_arrow_commit() {
   pushd $REPO_DIR
 
-  conda update -y -n base conda
+  (conda update -y -n base conda && conda install -y -n base conda-libmamba-solver) || echo 'moving on'
+  conda -V
+  conda config --set solver libmamba
+
   conda create -y -n "${BENCHMARKABLE_TYPE}" -c conda-forge \
-  --solver libmamba \
   --file ci/conda_env_unix.txt \
   --file ci/conda_env_cpp.txt \
   --file ci/conda_env_python.txt \

--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -8,6 +8,7 @@ create_conda_env_for_arrow_commit() {
   pushd $REPO_DIR
 
   conda create -y -n "${BENCHMARKABLE_TYPE}" -c conda-forge \
+  --solver libmamba \
   --file ci/conda_env_unix.txt \
   --file ci/conda_env_cpp.txt \
   --file ci/conda_env_python.txt \
@@ -18,13 +19,6 @@ create_conda_env_for_arrow_commit() {
 
   source dev/conbench_envs/hooks.sh activate_conda_env_for_benchmark_build
   source dev/conbench_envs/hooks.sh install_arrow_python_dependencies
-
-  # Workaround for https://github.com/aws/aws-sdk-cpp/issues/1820
-  conda install -y -c conda-forge cmake==3.21.3
-
-  # Archery does not work when using setuptools==60.9.0
-  conda install -y -c conda-forge setuptools==58.0.4
-
   source dev/conbench_envs/hooks.sh set_arrow_build_and_run_env_vars
 
   export RANLIB=`which $RANLIB`

--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -7,6 +7,7 @@ init_conda() {
 create_conda_env_for_arrow_commit() {
   pushd $REPO_DIR
 
+  conda update -n base conda
   conda create -y -n "${BENCHMARKABLE_TYPE}" -c conda-forge \
   --solver libmamba \
   --file ci/conda_env_unix.txt \

--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -7,7 +7,7 @@ init_conda() {
 create_conda_env_for_arrow_commit() {
   pushd $REPO_DIR
 
-  conda update -n base conda
+  conda update -y -n base conda
   conda create -y -n "${BENCHMARKABLE_TYPE}" -c conda-forge \
   --solver libmamba \
   --file ci/conda_env_unix.txt \


### PR DESCRIPTION
Fixes #103. Tells conda to use the mamba solver. I thought this was easier than going through and installing mamba on all our machines.