### PR TITLE
Publish results for all current machines

### DIFF
--- a/config.py
+++ b/config.py
@@ -215,7 +215,7 @@ class Config:
             },
             "supported_filters": ["lang", "name"],
             "offline_warning_enabled": False,
-            "publish_benchmark_results": False,
+            "publish_benchmark_results": True,
             "max_builds": 2,
         },
         "arm64-m6g-linux-compute": {
@@ -231,7 +231,7 @@ class Config:
             },
             "supported_filters": ["lang", "name"],
             "offline_warning_enabled": False,
-            "publish_benchmark_results": False,
+            "publish_benchmark_results": True,
             "max_builds": 2,
         },
         "ec2-m5-4xlarge-us-east-2": {
@@ -245,7 +245,7 @@ class Config:
             },
             "supported_filters": ["lang", "name"],
             "offline_warning_enabled": False,
-            "publish_benchmark_results": False,
+            "publish_benchmark_results": True,
             "max_builds": 2,
         },
     }

--- a/models/benchalerts_run.py
+++ b/models/benchalerts_run.py
@@ -22,9 +22,9 @@ from logger import log
 from models.base import BaseMixin
 from utils import generate_uuid
 
-MACHINES_TO_NOT_ANALYZE = ["test-mac-arm"]
 MACHINES_WITH_PUBLIC_BK_URLS = [
     "ec2-t3-xlarge-us-east-2",
+    "test-mac-arm",
     "ursa-i9-9960x",
     "ursa-thinkcentre-m75q",
 ]
@@ -101,11 +101,7 @@ class BenchalertsRun(Base, BaseMixin):
             conbench_client = None
             github_client = None
 
-        run_ids = [
-            run.id
-            for run in self.benchmarkable.runs
-            if run.machine_name not in MACHINES_TO_NOT_ANALYZE
-        ]
+        run_ids = [run.id for run in self.benchmarkable.runs]
         log.info(f"Analyzing run IDs: {run_ids}")
 
         possible_build_urls = [


### PR DESCRIPTION
This PR changes the GitHub messages to report on all machines that were run, instead of a subset.

- Turns on `test-mac-arm` analysis again (it was turned off in https://github.com/voltrondata-labs/arrow-benchmarks-ci/pull/109). This should be okay because of our new, different handling of known-unstable benchmarks.
- Changes the Voltron Data-managed machines' `publish_benchmark_results` attribute to True, which probably should have already been done a while ago, per [the docs](https://github.com/voltrondata-labs/arrow-benchmarks-ci/blob/main/docs/how-to-add-new-benchmark-machine-for-running-apache-arrow-benchmarks.md#10-create-pull-request-to-enable-publish_benchmark_results-for-your-machine). (Note that this is a bit of a misnomer; we've been publishing results for these machines for a while, but not waiting for them to finish before posting the notification.)