### PR TITLE
Add machine-level build timeout

### DIFF
--- a/buildkite/benchmark-test/run_test_builds.py
+++ b/buildkite/benchmark-test/run_test_builds.py
@@ -17,6 +17,7 @@ def run_test_builds():
         env = {
             "BENCHMARKABLE": "HEAD",
             "BENCHMARKABLE_TYPE": benchmarkable_type,
+            "BUILD_TIMEOUT": Config.MACHINES[machine]["build_timeout"],
             "FILTERS": json.dumps(
                 Config.MACHINES[machine]["default_filters"][benchmarkable_type]
             ),

--- a/buildkite/benchmark/pipeline.yml
+++ b/buildkite/benchmark/pipeline.yml
@@ -1,4 +1,4 @@
 steps:
   - label: "Run Benchmarks"
     command: source buildkite/benchmark/utils.sh create_conda_env_and_run_benchmarks
-    timeout_in_minutes: 360
+    timeout_in_minutes: $BUILD_TIMEOUT

--- a/config.py
+++ b/config.py
@@ -134,6 +134,7 @@ class Config:
             "offline_warning_enabled": True,
             "publish_benchmark_results": True,
             "max_builds": 1,
+            "build_timeout": 160,
         },
         "ursa-thinkcentre-m75q": {
             "info": "Supported benchmark langs: C++, Java",
@@ -158,6 +159,7 @@ class Config:
             "offline_warning_enabled": True,
             "publish_benchmark_results": True,
             "max_builds": 1,
+            "build_timeout": 150,
         },
         "ec2-t3-xlarge-us-east-2": {
             "info": "Supported benchmark langs: Python, R. Runs only benchmarks with cloud = True",
@@ -186,6 +188,7 @@ class Config:
             "offline_warning_enabled": False,
             "publish_benchmark_results": True,
             "max_builds": 1,
+            "build_timeout": 30,
         },
         "test-mac-arm": {
             "info": "Supported benchmark langs: C++, Python, R",
@@ -201,6 +204,7 @@ class Config:
             "offline_warning_enabled": False,
             "publish_benchmark_results": True,
             "max_builds": 1,
+            "build_timeout": 120,
         },
         "arm64-t4g-linux-compute": {
             "info": "Supported benchmark langs: C++, Python, R",
@@ -217,6 +221,7 @@ class Config:
             "offline_warning_enabled": False,
             "publish_benchmark_results": True,
             "max_builds": 2,
+            "build_timeout": 200,
         },
         "arm64-m6g-linux-compute": {
             "info": "Supported benchmark langs: C++, Python, R",
@@ -233,6 +238,7 @@ class Config:
             "offline_warning_enabled": False,
             "publish_benchmark_results": True,
             "max_builds": 2,
+            "build_timeout": 300,
         },
         "ec2-m5-4xlarge-us-east-2": {
             "info": "Supported benchmark langs: R",
@@ -247,5 +253,6 @@ class Config:
             "offline_warning_enabled": False,
             "publish_benchmark_results": True,
             "max_builds": 2,
+            "build_timeout": 200,
         },
     }

--- a/migrations/versions/5917e6566e6b_add_machine_build_timeout.py
+++ b/migrations/versions/5917e6566e6b_add_machine_build_timeout.py
@@ -1,0 +1,25 @@
+"""add machine build_timeout
+
+Revision ID: 5917e6566e6b
+Revises: c30e58775d47
+Create Date: 2024-03-25 14:41:06.064070
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "5917e6566e6b"
+down_revision = "c30e58775d47"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("machine", sa.Column("build_timeout", sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("machine", "build_timeout")

--- a/models/machine.py
+++ b/models/machine.py
@@ -28,6 +28,7 @@ class Machine(Base, BaseMixin):
     ip_address = Nullable(s.String)
     port = Nullable(s.Integer)
     max_builds = NotNull(s.Integer, server_default="1")
+    build_timeout = Nullable(s.Integer)
     runs = relationship("Run", backref=backref("machine", lazy="joined"))
 
     @property

--- a/models/run.py
+++ b/models/run.py
@@ -114,6 +114,7 @@ class Run(Base, BaseMixin):
             "BENCHMARKABLE": self.benchmarkable_id,
             "BENCHMARKABLE_TYPE": self.benchmarkable.type,
             "BENCHMARKABLE_PR_NUMBER": pr_number,
+            "BUILD_TIMEOUT": self.machine.build_timeout,
             "FILTERS": json.dumps(self.filters),
             "MACHINE": self.machine_name,
             "RUN_ID": self.id,


### PR DESCRIPTION
This PR enables each machine to have a different Buildkite timeout.

This will help in the intermediate fallout of https://github.com/apache/arrow/issues/40775 because that's causing the `ursa-thinkcentre-m75q` machine to time out after 6 hours. This PR reduces that to 2.5 hours.

This should also help with https://github.com/voltrondata-labs/arrow-benchmarks-ci/issues/173 (not the cause, but the symptom).