### PR TITLE
Install archery differently

### DIFF
--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -39,14 +39,14 @@ repos_with_benchmark_groups = [
         "path_to_benchmark_groups_list_json": "benchmarks/benchmarks.json",
         "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/benchmarks/main/benchmarks.json",
         "setup_commands_for_lang_benchmarks": {  # These commands need to be defined as functions in buildkite/benchmark/utils.sh
-            "C++": ["install_archery"],
+            "C++": [],
             "Python": ["create_data_dir"],
             "R": [
                 "build_arrow_r",
                 "install_arrowbench",
                 "create_data_dir",
             ],
-            "Java": ["build_arrow_java", "install_archery"],
+            "Java": ["build_arrow_java"],
             "JavaScript": ["install_java_script_project_dependencies"],
         },
         "env_vars": {
@@ -84,14 +84,14 @@ repos_with_benchmark_groups = [
         "path_to_benchmark_groups_list_json": "arrow-benchmarks-ci/adapters/benchmarks.json",
         "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/arrow-benchmarks-ci/main/adapters/benchmarks.json",
         "setup_commands_for_lang_benchmarks": {  # These commands need to be defined as functions in buildkite/benchmark/utils.sh
-            "C++": ["install_archery"],
+            "C++": [],
             "Python": ["create_data_dir"],
             "R": [
                 "build_arrow_r",
                 "install_arrowbench",
                 "create_data_dir",
             ],
-            "Java": ["build_arrow_java", "install_archery"],
+            "Java": ["build_arrow_java"],
             "JavaScript": ["install_java_script_project_dependencies"],
         },
         "env_vars": {

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -34,7 +34,7 @@ repos_with_benchmark_groups = [
         "benchmarkable_type": "arrow-commit",
         "repo": "https://github.com/voltrondata-labs/benchmarks.git",
         "root": "benchmarks",
-        "branch": "main",
+        "branch": "aus/build",
         "setup_commands": ["pip install -e ."],
         "path_to_benchmark_groups_list_json": "benchmarks/benchmarks.json",
         "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/benchmarks/main/benchmarks.json",

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -317,12 +317,14 @@ class CommandExecutor:
         if log_stdout:
             child = subprocess.run(
                 f"cd {path}; {command}",
-                capture_output=True,
+                # capture_output=True,
                 shell=True,
                 executable="/bin/bash",
             )
-            stderr = child.stderr.decode()
-            stdout = child.stdout.decode()
+            # stderr = child.stderr.decode()
+            # stdout = child.stdout.decode()
+            stderr = ""
+            stdout = ""
         else:
             # Do not log Java benchmarks stdout (12GB+)
             # Note(JP): and what about stderr?

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -34,7 +34,7 @@ repos_with_benchmark_groups = [
         "benchmarkable_type": "arrow-commit",
         "repo": "https://github.com/voltrondata-labs/benchmarks.git",
         "root": "benchmarks",
-        "branch": "aus/build",
+        "branch": "main",
         "setup_commands": ["pip install -e ."],
         "path_to_benchmark_groups_list_json": "benchmarks/benchmarks.json",
         "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/benchmarks/main/benchmarks.json",
@@ -317,14 +317,12 @@ class CommandExecutor:
         if log_stdout:
             child = subprocess.run(
                 f"cd {path}; {command}",
-                # capture_output=True,
+                capture_output=True,
                 shell=True,
                 executable="/bin/bash",
             )
-            # stderr = child.stderr.decode()
-            # stdout = child.stdout.decode()
-            stderr = ""
-            stdout = ""
+            stderr = child.stderr.decode()
+            stdout = child.stdout.decode()
         else:
             # Do not log Java benchmarks stdout (12GB+)
             # Note(JP): and what about stderr?

--- a/buildkite/benchmark/run.py
+++ b/buildkite/benchmark/run.py
@@ -39,7 +39,7 @@ repos_with_benchmark_groups = [
         "path_to_benchmark_groups_list_json": "benchmarks/benchmarks.json",
         "url_for_benchmark_groups_list_json": "https://raw.githubusercontent.com/voltrondata-labs/benchmarks/main/benchmarks.json",
         "setup_commands_for_lang_benchmarks": {  # These commands need to be defined as functions in buildkite/benchmark/utils.sh
-            "C++": [],
+            "C++": ["install_minio"],
             "Python": ["create_data_dir"],
             "R": [
                 "build_arrow_r",

--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -79,6 +79,12 @@ build_arrow_java() {
   popd
 }
 
+install_minio() {
+  pushd $REPO_DIR
+  ci/scripts/install_minio.sh latest ${ARROW_HOME}
+  popd
+}
+
 install_arrowbench() {
   # do I need to cd into benchmarks dir?
   git clone https://github.com/voltrondata-labs/arrowbench.git

--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -27,6 +27,7 @@ create_conda_env_for_arrow_commit() {
 
   source dev/conbench_envs/hooks.sh build_arrow_cpp
   source dev/conbench_envs/hooks.sh build_arrow_python
+  source dev/conbench_envs/hooks.sh install_archery
   popd
 }
 
@@ -75,14 +76,6 @@ build_arrow_r() {
 build_arrow_java() {
   pushd $REPO_DIR
   source dev/conbench_envs/hooks.sh build_arrow_java
-  popd
-}
-
-install_archery() {
-  clone_repo
-  pushd $REPO_DIR
-  source dev/conbench_envs/hooks.sh build_arrow_python
-  source dev/conbench_envs/hooks.sh install_archery
   popd
 }
 

--- a/config.py
+++ b/config.py
@@ -159,7 +159,7 @@ class Config:
             "offline_warning_enabled": True,
             "publish_benchmark_results": True,
             "max_builds": 1,
-            "build_timeout": 150,
+            "build_timeout": 360,
         },
         "ec2-t3-xlarge-us-east-2": {
             "info": "Supported benchmark langs: Python, R. Runs only benchmarks with cloud = True",

--- a/config.py
+++ b/config.py
@@ -71,67 +71,67 @@ class Config:
             "info": "Supported benchmark langs: Python, R, JavaScript. Skips certain "
             "commit messages if they contain certain strings.",
             "default_filters": {
-                "arrow-commit": {
-                    "langs": {
-                        "Python": {
-                            "names": [
-                                "csv-read",
-                                "dataframe-to-table",
-                                "dataset-filter",
-                                "dataset-read",
-                                "dataset-select",
-                                "dataset-selectivity",
-                                "dataset-serialize",
-                                "file-read",
-                                "file-write",
-                                "recursive-get-file-info",
-                                "wide-dataframe",
-                            ]
-                        },
-                        "R": {
-                            "names": [
-                                "dataframe-to-table",
-                                "file-read",
-                                "file-write",
-                                "partitioned-dataset-filter",
-                                "wide-dataframe",
-                                "tpch",
-                            ]
-                        },
-                        "JavaScript": {"names": ["js-micro"]},
-                    },
-                    "commit_message_skip_strings": [
-                        "[C#]",
-                        "[CI]",
-                        "[Doc]",
-                        "[Docs]",
-                        "[Go]",
-                        "[Java]",
-                        "[MATLAB]",
-                    ],
-                },
-                "pyarrow-apache-wheel": {
-                    "langs": {
-                        "Python": {
-                            "names": [
-                                "csv-read",
-                                "dataframe-to-table",
-                                "dataset-filter",
-                                "dataset-read",
-                                "dataset-select",
-                                "dataset-selectivity",
-                                "dataset-serialize",
-                                "file-read",
-                                "file-write",
-                                "recursive-get-file-info",
-                                "wide-dataframe",
-                            ]
-                        }
-                    },
-                },
+                # "arrow-commit": {
+                #     "langs": {
+                #         "Python": {
+                #             "names": [
+                #                 "csv-read",
+                #                 "dataframe-to-table",
+                #                 "dataset-filter",
+                #                 "dataset-read",
+                #                 "dataset-select",
+                #                 "dataset-selectivity",
+                #                 "dataset-serialize",
+                #                 "file-read",
+                #                 "file-write",
+                #                 "recursive-get-file-info",
+                #                 "wide-dataframe",
+                #             ]
+                #         },
+                #         "R": {
+                #             "names": [
+                #                 "dataframe-to-table",
+                #                 "file-read",
+                #                 "file-write",
+                #                 "partitioned-dataset-filter",
+                #                 "wide-dataframe",
+                #                 "tpch",
+                #             ]
+                #         },
+                #         "JavaScript": {"names": ["js-micro"]},
+                #     },
+                #     "commit_message_skip_strings": [
+                #         "[C#]",
+                #         "[CI]",
+                #         "[Doc]",
+                #         "[Docs]",
+                #         "[Go]",
+                #         "[Java]",
+                #         "[MATLAB]",
+                #     ],
+                # },
+                # "pyarrow-apache-wheel": {
+                #     "langs": {
+                #         "Python": {
+                #             "names": [
+                #                 "csv-read",
+                #                 "dataframe-to-table",
+                #                 "dataset-filter",
+                #                 "dataset-read",
+                #                 "dataset-select",
+                #                 "dataset-selectivity",
+                #                 "dataset-serialize",
+                #                 "file-read",
+                #                 "file-write",
+                #                 "recursive-get-file-info",
+                #                 "wide-dataframe",
+                #             ]
+                #         }
+                #     },
+                # },
             },
             "supported_filters": ["lang", "name"],
-            "offline_warning_enabled": True,
+            "offline_warning_enabled": False,
             "publish_benchmark_results": True,
             "max_builds": 1,
             "build_timeout": 160,
@@ -139,27 +139,27 @@ class Config:
         "ursa-thinkcentre-m75q": {
             "info": "Supported benchmark langs: C++, Java",
             "default_filters": {
-                "arrow-commit": {
-                    "langs": {
-                        "C++": {"names": ["cpp-micro"]},
-                        "Java": {"names": ["java-micro"]},
-                    },
-                    "commit_message_skip_strings": [
-                        "[C#]",
-                        "[CI]",
-                        "[Doc]",
-                        "[Docs]",
-                        "[Go]",
-                        "[JavaScript]",
-                        "[MATLAB]",
-                    ],
-                }
+                # "arrow-commit": {
+                #     "langs": {
+                #         "C++": {"names": ["cpp-micro"]},
+                #         "Java": {"names": ["java-micro"]},
+                #     },
+                #     "commit_message_skip_strings": [
+                #         "[C#]",
+                #         "[CI]",
+                #         "[Doc]",
+                #         "[Docs]",
+                #         "[Go]",
+                #         "[JavaScript]",
+                #         "[MATLAB]",
+                #     ],
+                # }
             },
             "supported_filters": ["lang", "command"],
-            "offline_warning_enabled": True,
+            "offline_warning_enabled": False,
             "publish_benchmark_results": True,
             "max_builds": 1,
-            "build_timeout": 360,
+            "build_timeout": 150,
         },
         "ec2-t3-xlarge-us-east-2": {
             "info": "Supported benchmark langs: Python, R. Runs only benchmarks with cloud = True",
@@ -193,12 +193,12 @@ class Config:
         "test-mac-arm": {
             "info": "Supported benchmark langs: C++, Python, R",
             "default_filters": {
-                "arrow-commit": {
-                    "langs": {
-                        "C++": {"names": ["cpp-micro"]},
-                        "R": {"names": ["tpch"]},
-                    }
-                },
+                # "arrow-commit": {
+                #     "langs": {
+                #         "C++": {"names": ["cpp-micro"]},
+                #         "R": {"names": ["tpch"]},
+                #     }
+                # },
             },
             "supported_filters": ["lang", "name"],
             "offline_warning_enabled": False,

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -16,7 +16,9 @@ expected_setup_commands = [
     ("pip install -e .", "benchmarks", True),
 ]
 
-expected_setup_commands_for_cpp_benchmarks = []
+expected_setup_commands_for_cpp_benchmarks = [
+    ("source buildkite/benchmark/utils.sh install_minio", ".", True),
+]
 
 expected_setup_commands_for_r_benchmarks = [
     ("source buildkite/benchmark/utils.sh build_arrow_r", ".", True),

--- a/tests/buildkite/benchmark/test_run_benchmarks.py
+++ b/tests/buildkite/benchmark/test_run_benchmarks.py
@@ -16,9 +16,7 @@ expected_setup_commands = [
     ("pip install -e .", "benchmarks", True),
 ]
 
-expected_setup_commands_for_cpp_benchmarks = [
-    ("source buildkite/benchmark/utils.sh install_archery", ".", True),
-]
+expected_setup_commands_for_cpp_benchmarks = []
 
 expected_setup_commands_for_r_benchmarks = [
     ("source buildkite/benchmark/utils.sh build_arrow_r", ".", True),
@@ -210,9 +208,9 @@ def test_run_benchmarks():
     ][0]
     # These tests should use benchmarks.json in benchmarks repo but should not be affected any new benchmarks
     # that added since 2b217db086260ab3bb243e26253b7c1de0180777
-    repo[
-        "url_for_benchmark_groups_list_json"
-    ] = "https://raw.githubusercontent.com/voltrondata-labs/benchmarks/2b217db086260ab3bb243e26253b7c1de0180777/benchmarks.json"
+    repo["url_for_benchmark_groups_list_json"] = (
+        "https://raw.githubusercontent.com/voltrondata-labs/benchmarks/2b217db086260ab3bb243e26253b7c1de0180777/benchmarks.json"
+    )
     for test in tests:
         print(test)
         run = MockRun(repo, test["run_filters"])
@@ -236,9 +234,9 @@ def test_run_arrowbench_benchmarks(monkeypatch):
     ][0]
     # These tests should use benchmarks.json in arrowbench repo but should not be affected any new benchmarks
     # that added since c5e5af241f17d27aadc01548f283a2a977151b91
-    repo[
-        "url_for_benchmark_groups_list_json"
-    ] = "https://raw.githubusercontent.com/voltrondata-labs/arrowbench/c5e5af241f17d27aadc01548f283a2a977151b91/inst/benchmarks.json"
+    repo["url_for_benchmark_groups_list_json"] = (
+        "https://raw.githubusercontent.com/voltrondata-labs/arrowbench/c5e5af241f17d27aadc01548f283a2a977151b91/inst/benchmarks.json"
+    )
 
     filter_with_arrowbench_r_only_benchmarks = deepcopy(filter_with_r_only_benchmarks)
     filter_with_arrowbench_r_only_benchmarks["langs"]["R"]["names"] = [
@@ -309,9 +307,9 @@ def test_run_adapter_benchmarks():
     ][0]
     # These tests should use benchmarks.json in arrow-benchmarks-ci repo but should not be affected any new benchmarks
     # that added since 1ca33e8800a11624faf89a85af817ca83e473f56
-    repo[
-        "url_for_benchmark_groups_list_json"
-    ] = "https://raw.githubusercontent.com/voltrondata-labs/arrow-benchmarks-ci/1ca33e8800a11624faf89a85af817ca83e473f56/adapters/benchmarks.json"
+    repo["url_for_benchmark_groups_list_json"] = (
+        "https://raw.githubusercontent.com/voltrondata-labs/arrow-benchmarks-ci/1ca33e8800a11624faf89a85af817ca83e473f56/adapters/benchmarks.json"
+    )
 
     filters = {
         "langs": {


### PR DESCRIPTION
Pairs well with https://github.com/voltrondata-labs/benchmarks/pull/159 and https://github.com/apache/arrow/pull/40925.

This PR
- installs archery every time in the main conda section instead of only during runs that need it, due to it being fast and depending on stuff that's installed every time
- turns off scheduling for ursa-i9-9960x, ursa-thinkcentre-m75q, test-mac-arm (temporarily until they're back up)