### PR TITLE
truncate big summaries

### DIFF
--- a/models/benchalerts_run.py
+++ b/models/benchalerts_run.py
@@ -321,6 +321,9 @@ class ArrowAlerter(Alerter):
             )
             summary += _list_results(unstable_comparison.results_with_z_regressions)
 
+        if len(summary) > 65535:
+            summary = summary[:65532] + "..."
+
         return summary
 
     def github_pr_comment(


### PR DESCRIPTION
GitHub doesn't allow for more than 65535 characters in a check run summary. Ran into this problem here: https://github.com/apache/arrow/runs/23845558283