### PR TITLE
Bump down i9 timeout

### DIFF
--- a/config.py
+++ b/config.py
@@ -134,7 +134,7 @@ class Config:
             "offline_warning_enabled": False,
             "publish_benchmark_results": True,
             "max_builds": 1,
-            "build_timeout": 240,
+            "build_timeout": 180,
         },
         "ursa-thinkcentre-m75q": {
             "info": "Supported benchmark langs: C++, Java",


### PR DESCRIPTION
After monitoring the change in #188, turns out a 3h timeout should be sufficient.