### PR TITLE
Move to cpp to t3

### DIFF
--- a/config.py
+++ b/config.py
@@ -201,7 +201,7 @@ class Config:
             "offline_warning_enabled": False,
             "publish_benchmark_results": True,
             "max_builds": 1,
-            "build_timeout": 270,
+            "build_timeout": 180,
         },
         "test-mac-arm": {
             "info": "Supported benchmark langs: C++, Python, R",

--- a/config.py
+++ b/config.py
@@ -201,7 +201,7 @@ class Config:
             "offline_warning_enabled": False,
             "publish_benchmark_results": True,
             "max_builds": 1,
-            "build_timeout": 90,
+            "build_timeout": 270,
         },
         "test-mac-arm": {
             "info": "Supported benchmark langs: C++, Python, R",

--- a/config.py
+++ b/config.py
@@ -184,6 +184,7 @@ class Config:
                             ]
                         },
                         "JavaScript": {"names": ["js-micro"]},
+                        "C++": {"names": ["cpp-micro"]},
                     }
                 },
                 "benchmarkable-repo-commit": {
@@ -241,7 +242,6 @@ class Config:
                 "arrow-commit": {
                     "langs": {
                         "Python": {"names": ["dataset-read", "dataset-select"]},
-                        "C++": {"names": ["cpp-micro"]},
                         "R": {"names": ["tpch"]},
                     }
                 },


### PR DESCRIPTION
Successful test run here: https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-ec2-t3-xlarge-us-east-2/builds/5095

I did up the timeout because the first test run did timeout. Took the value from others that run a similar suite. 