### PR TITLE
temporarily ceiling setuptools

### DIFF
--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -14,6 +14,7 @@ create_conda_env_for_arrow_commit() {
   --file ci/conda_env_python.txt \
   compilers \
   python="${PYTHON_VERSION}" \
+  'setuptools<71' \
   pandas \
   r
 


### PR DESCRIPTION
Due to https://github.com/pypa/setuptools/issues/4476 (or whatever new issue comes out of that), all Arrow benchmarks are failing. This should temporarily fix them until the root cause is fixed.