### PR TITLE
Revert "temporarily ceiling setuptools (#210)"

### DIFF
--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -14,7 +14,6 @@ create_conda_env_for_arrow_commit() {
   --file ci/conda_env_python.txt \
   compilers \
   python="${PYTHON_VERSION}" \
-  'setuptools<71' \
   pandas \
   r
 


### PR DESCRIPTION
This reverts commit b3418281a6a5ddcd1a9653aed34af9a06403966e.

This issue is fixed: https://github.com/pypa/setuptools/issues/4508