### PR TITLE
Move psycopg2 to conda to avoid source build

### DIFF
--- a/buildkite/benchmark/utils.sh
+++ b/buildkite/benchmark/utils.sh
@@ -142,6 +142,8 @@ create_conda_env_and_run_benchmarks() {
       ;;
   esac
 
+  # pypi doesn't have wheels for macos 13 and source build fails
+  conda install psycopg2-binary
   pip install -r requirements.txt
   python -m buildkite.benchmark.run_benchmark_groups
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ flask-restful
 gunicorn
 itsdangerous==2.0.1
 psutil
-psycopg2-binary
 requests
 setuptools
 SQLAlchemy>=1.4.0b1


### PR DESCRIPTION
To fix: https://buildkite.com/apache-arrow/arrow-bci-benchmark-on-test-mac-arm/builds/6342