### PR TITLE
Disable java benchmarks

### DIFF
--- a/config.py
+++ b/config.py
@@ -88,7 +88,7 @@ class Config:
                 "arrow-commit": {
                     "langs": {
                         "C++": {"names": ["cpp-micro"]},
-                        "Java": {"names": ["java-micro"]},
+                        # "Java": {"names": ["java-micro"]},
                     }
                 }
             },
@@ -145,7 +145,7 @@ class Config:
                         },
                         "JavaScript": {"names": ["js-micro"]},
                         "C++": {"names": ["cpp-micro"]},
-                        "Java": {"names": ["java-micro"]},
+                        # "Java": {"names": ["java-micro"]},
                     },
                 },
             },


### PR DESCRIPTION
They are failing due to the java implementation being removed from the monorepo.
See https://github.com/apache/arrow/issues/44996